### PR TITLE
Issue 10 - add space to 'file'-regex-part to reduce false positives

### DIFF
--- a/antivirus.php
+++ b/antivirus.php
@@ -690,7 +690,7 @@ class AntiVirus {
 	 * @return string Regular expression.
 	 */
 	private static function _php_match_pattern() {
-		return '/(assert|file_get_contents|curl_exec|popen|proc_open|unserialize|eval|base64_encode|base64_decode|create_function|exec|shell_exec|system|passthru|ob_get_contents| file|curl_init|readfile|fopen|fsockopen|pfsockopen|fclose|fread|file_put_contents)\s*?\(/';
+		return '/(assert|file_get_contents|curl_exec|popen|proc_open|unserialize|eval|base64_encode|base64_decode|create_function|exec|shell_exec|system|passthru|ob_get_contents|\bfile\b|curl_init|readfile|fopen|fsockopen|pfsockopen|fclose|fread|file_put_contents)\s*?\(/';
 	}
 
 	/**

--- a/antivirus.php
+++ b/antivirus.php
@@ -690,7 +690,7 @@ class AntiVirus {
 	 * @return string Regular expression.
 	 */
 	private static function _php_match_pattern() {
-		return '/(assert|file_get_contents|curl_exec|popen|proc_open|unserialize|eval|base64_encode|base64_decode|create_function|exec|shell_exec|system|passthru|ob_get_contents|\bfile\b|curl_init|readfile|fopen|fsockopen|pfsockopen|fclose|fread|file_put_contents)\s*?\(/';
+		return '/\b(assert|file_get_contents|curl_exec|popen|proc_open|unserialize|eval|base64_encode|base64_decode|create_function|exec|shell_exec|system|passthru|ob_get_contents|file|curl_init|readfile|fopen|fsockopen|pfsockopen|fclose|fread|file_put_contents)\b\s*?\(/';
 	}
 
 	/**

--- a/css/style.css
+++ b/css/style.css
@@ -82,10 +82,6 @@
 	background: yellow;
 }
 
-#av_main tr{
-	vertical-align: top;
-}
-
 /* @end group */
 
 


### PR DESCRIPTION
Would solve https://github.com/pluginkollektiv/antivirus/issues/10

It's just a suggestion. This change would still catch the usage of `file()`, but maybe there was more thought involved than just prohibit this function to use.