### PR TITLE
Tested on 4.8 and 4.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 * Tags:              antivirus, malware, scanner, phishing, safe browsing, vulnerability
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=8CH5FPR88QYML
 * Requires at least: 3.8
-* Tested up to:      4.7
+* Tested up to:      4.9
 * Stable tag:        1.3.9
 * License:           GPLv2 or later
 * License URI:       http://www.gnu.org/licenses/gpl-2.0.html

--- a/antivirus.php
+++ b/antivirus.php
@@ -1017,7 +1017,7 @@ class AntiVirus {
 							<?php
 							if ( substr( get_locale(), 0, 3 ) === 'de_' ) {
 								printf(
-									'<a href="%s" target="_blank">%s</a>',
+									'<a href="%s" target="_blank">%s</a> ',
 									'https://github.com/pluginkollektiv/antivirus/wiki',
 									'Handbuch'
 								);


### PR DESCRIPTION
added blank between two links Handbook / Paypal
new suggestion for german translation "there is no virus"