### PR TITLE
Custom Safe Browsing API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### unreleased ###
+* **English**
+	 * Option to provide a custom key for the Google Safe Browsing API
+* **Deutsch**
+	* Möglichkeit einen eigenen Schlüssel für die Google Safe Browsing API zu verwenden
+
+
 ### 1.3.10 ###
 * **English**
 	 * Updated PayPal link for donations

--- a/antivirus.php
+++ b/antivirus.php
@@ -347,14 +347,14 @@ class AntiVirus {
 			$mail_body = sprintf(
 				"%s\r\n\r\n%s",
 				esc_html__( 'Checking yout site against the Google Safe Browsing API has failed.', 'antivirus' ),
-				esc_html__( 'This does not mean that your site has been infected, but that the status could not be determinined.', 'antivirus' ),
+				esc_html__( 'This does not mean that your site has been infected, but that the status could not be determinined.', 'antivirus' )
 			);
 
 			// Add (sanitized) error message, if available
 			if ( isset( $response_json['error']['message'] ) ) {
 				$mail_body .= sprintf(
-					"\r\n\r\n%s:  %s\r\n",
-					esc_html__( '', 'antivirus' ),
+					"\r\n\r\n%s:\r\n  %s\r\n",
+					esc_html__( 'Error message from API', 'antivirus' ),
 					filter_var( $response_json['error']['message'], FILTER_SANITIZE_STRING )
 				);
 			}

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,15 @@
 {
   "name": "pluginkollektiv/antivirus",
   "description": "Security plugin to protect your blog or website against exploits and spam injections.",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "type": "wordpress-plugin",
   "license": "GPL-2.0+",
   "require": {
     "composer/installers": "~1.0"
   },
   "require-dev": {
+    "lipemat/wp-unit": "^1.5",
+    "phpunit/phpunit": "^7.0",
     "wp-coding-standards/wpcs": "dev-develop"
   },
   "scripts": {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,3 +17,6 @@ function _manually_load_oembed_api_plugin() {
 tests_add_filter( 'muplugins_loaded', '_manually_load_oembed_api_plugin' );
 
 require $_tests_dir . '/includes/bootstrap.php';
+
+// Include custom mocks.
+require 'wp_mocks.php';

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -15,4 +15,207 @@ class AntiVirus_Test_Plugin extends WP_UnitTestCase {
 	function test_plugin_activated() {
 		$this->assertTrue( class_exists( 'AntiVirus' ) );
 	}
+
+
+	/**
+	 * Test the Safe Browsing check.
+	 */
+	function test_safe_browsing() {
+		/*
+		 * Case 1: cron job disabled, Safe Browsing enabled.
+		 */
+		update_option(
+			'antivirus',
+			array(
+				'cronjob_enable'    => 1,
+				'notify_email'      => '',
+				'safe_browsing'     => 1,
+				'safe_browsing_key' => '',
+			)
+		);
+
+		AntiVirus::do_daily_cronjob();
+
+		$this->assertNotNull( get_wp_remote_post_request(), 'Remote POST should have been called (Safe Browsing check executed)' );
+		$this->assertNull( get_wp_mail(), 'No mail should have been sent' );
+
+		/*
+		 * Case 2: cron job ensabled, Safe Browsing disabled.
+		 */
+		update_option(
+			'antivirus',
+			array(
+				'cronjob_enable'    => 1,
+				'notify_email'      => '',
+				'safe_browsing'     => 0,
+				'safe_browsing_key' => '',
+			)
+		);
+
+		AntiVirus::do_daily_cronjob();
+
+		$this->assertNotNull( get_wp_remote_post_request(), 'Remote POST should have been called (Safe Browsing check executed)' );
+		$this->assertNull( get_wp_mail(), 'No mail should have been sent' );
+
+		/*
+		 * Case 3: cron job enabled, Safe Browsing enabled, default key.
+		 */
+		update_option(
+			'antivirus',
+			array(
+				'cronjob_enable'    => 1,
+				'notify_email'      => '',
+				'safe_browsing'     => 1,
+				'safe_browsing_key' => '',
+			)
+		);
+
+		AntiVirus::do_daily_cronjob();
+
+		$request = get_wp_remote_post_request();
+		$this->assertNotNull( $request, 'Remote POST should have been called (Safe Browsing check executed)' );
+		$this->assertNull( get_wp_mail(), 'No mail should have been sent' );
+		$this->assertStringEndsWith( '?key=AIzaSyCGHXUd7vQAySRLNiC5y1M_wzR2W0kCVKI', $request[0], 'Default API key should have been used' );
+
+		// Check if JSON request is correct.
+		$this->assertEquals( 'application/json', $request[1]['headers']['Content-Type'], 'Content-Type header not correct' );
+		$json_request = json_decode( $request[1]['body'] );
+		$this->assertNotNull( $json_request, 'Invalid JSON in body' );
+		$this->assertEquals( 1, count( $json_request->threatInfo->threatEntries ), 'Unexpected number of site URLs' );
+		$this->assertEquals( urlencode( 'http://example.org' ), $json_request->threatInfo->threatEntries[0]->url, 'Invalid site URL in request' );
+
+		/*
+		 * Case 4: with custom API key.
+		 */
+		update_option(
+			'antivirus',
+			array(
+				'cronjob_enable'    => 1,
+				'notify_email'      => '',
+				'safe_browsing'     => 1,
+				'safe_browsing_key' => 'my-custom-key',
+			)
+		);
+		AntiVirus::do_daily_cronjob();
+		$request = get_wp_remote_post_request();
+		$this->assertNotNull( $request, 'Remote POST should have been called (Safe Browsing check executed)' );
+		$this->assertNull( get_wp_mail(), 'No mail should have been sent' );
+		$this->assertStringEndsWith( '?key=my-custom-key', $request[0], 'Custom API key should have been used' );
+		$this->assertEquals( $json_request, json_decode( $request[1]['body'] ), 'Request body should not differ from previous request with default key' );
+
+		/*
+		 * Case 5: Until now all checks have failed with WP_Error. Assume a correct 200 empty-body response.
+		 */
+		mock_wp_remote_post_response(
+			array(
+				'headers'  => array(),
+				'body'     => '',
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK'
+				)
+			)
+		);
+
+		AntiVirus::do_daily_cronjob();
+		$request = get_wp_remote_post_request();
+		$this->assertNotNull( $request, 'Remote POST should have been called (Safe Browsing check executed)' );
+		$this->assertNull( get_wp_mail(), 'No mail should have been sent' );
+		$this->assertStringEndsWith( '?key=my-custom-key', $request[0], 'Custom API key should have been used' );
+		$this->assertEquals( $json_request, json_decode( $request[1]['body'] ), 'Request body should not differ from previous request with default key' );
+
+		/*
+		 * Case 6: Successful request with threat content.
+		 */
+		clear_wp_remote_post_request();
+		clear_wp_remote_post_response();
+		mock_wp_remote_post_response(
+			array(
+				'headers'  => array(),
+				'body'     => '{"matches":[{"threatType":"MALWARE","platformType":"WINDOWS","threatEntryType":"URL","threat":{"url":"http://www.urltocheck1.org/"},"threatEntryMetadata":{"entries":[{"key":"malware_threat_type","value":"landing"}]},"cacheDuration":"300.000s"},{"threatType":"MALWARE","platformType":"WINDOWS","threatEntryType":"URL","threat":{"url":"http://www.urltocheck2.org/"},"threatEntryMetadata":{"entries":[{"key":"malware_threat_type","value":"landing"}]},"cacheDuration":"300.000s"}]}',
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK'
+				)
+			)
+		);
+
+		AntiVirus::do_daily_cronjob();
+		$request = get_wp_remote_post_request();
+		$this->assertNotNull( $request, 'Remote POST should have been called (Safe Browsing check executed)' );
+		$mail = get_wp_mail();
+		$this->assertNotNull( $mail, 'Mail should have been sent' );
+		$this->assertEquals('admin@example.org', $mail[0], 'Recipient should be default site admin');
+		$this->assertEquals('[Test Blog] Safe Browsing Alert', $mail[1], 'Not an alert message');
+
+		/*
+		 * Case 7: Same for configured noticifation address.
+		 */
+		update_option(
+			'antivirus',
+			array(
+				'cronjob_enable'    => 1,
+				'notify_email'      => 'testme@example.org',
+				'safe_browsing'     => 1,
+				'safe_browsing_key' => 'my-custom-key',
+			)
+		);
+
+		clear_wp_remote_post_request();
+		AntiVirus::do_daily_cronjob();
+		$request = get_wp_remote_post_request();
+		$this->assertNotNull( $request, 'Remote POST should have been called (Safe Browsing check executed)' );
+		$mail = get_wp_mail();
+		$this->assertNotNull( $mail, 'Mail should have been sent' );
+		$this->assertEquals('testme@example.org', $mail[0], 'Recipient should be configured address');
+		$this->assertEquals('[Test Blog] Safe Browsing Alert', $mail[1], 'Not an alert message');
+
+		/*
+		 * Case 8: Assume code 403 for an expired key.
+		 */
+		mock_wp_remote_post_response(
+			array(
+				'headers'  => array(),
+				'body'     => '{"error":{"message":"Quota exceeded"}}',
+				'response' => array(
+					'code'    => 403,
+					'message' => 'Forbidden'
+				)
+			)
+		);
+
+		clear_wp_remote_post_request();
+		AntiVirus::do_daily_cronjob();
+		$request = get_wp_remote_post_request();
+		$this->assertNotNull( $request, 'Remote POST should have been called (Safe Browsing check executed)' );
+		$mail = get_wp_mail();
+		$this->assertNotNull( $mail, 'Mail should have been sent' );
+		$this->assertEquals('testme@example.org', $mail[0], 'Recipient should be configured address');
+		$this->assertEquals('[Test Blog] Safe Browsing check failed', $mail[1], 'Not a "check-failed" message');
+		$this->assertContains("\r\n  Quota exceeded\r\n", $mail[2], 'Message from response not transported to mail');
+
+		/*
+		 * Case 9: Assume code 400 for invalid key.
+		 */
+		mock_wp_remote_post_response(
+			array(
+				'headers'  => array(),
+				'body'     => '{"error":{"message":"Invalid API key"}}',
+				'response' => array(
+					'code'    => 400,
+					'message' => 'Forbidden'
+				)
+			)
+		);
+
+		clear_wp_remote_post_request();
+		AntiVirus::do_daily_cronjob();
+		$request = get_wp_remote_post_request();
+		$this->assertNotNull( $request, 'Remote POST should have been called (Safe Browsing check executed)' );
+		$mail = get_wp_mail();
+		$this->assertNotNull( $mail, 'Mail should have been sent' );
+		$this->assertEquals('testme@example.org', $mail[0], 'Recipient should be configured address');
+		$this->assertEquals('[Test Blog] Safe Browsing check failed', $mail[1], 'Not a "check-failed" message');
+		$this->assertContains("\r\n  Invalid API key\r\n", $mail[2], 'Message from response not transported to mail');
+	}
 }

--- a/tests/wp_mocks.php
+++ b/tests/wp_mocks.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Mock support for interaction with the world.
+ *
+ * This file provides some helper methods for HTTP POST and mail interception.
+ * runkit or runkit7 are required to use these mocks.
+ */
+
+$antivirus_mock_wp_remote_requests = array();
+$antivirus_mock_wp_remote_response = array();
+$antivirus_mock_wp_mail_capture    = array();
+
+/**
+ * Mock result of wp_remote_post() call.
+ *
+ * If matchers are provided, the response will only be returned if the resquest matches both.
+ * Otherwise the response will always be returned.
+ *
+ * @param mixed        $result
+ * @param string|null  $url         Regular expression to match the URL (optional).
+ * @param Closure|null $arg_matcher Matcher function for request arguments (optional).
+ */
+function mock_wp_remote_post_response( $result, $url_matcher = null, $arg_matcher = null ) {
+	global $antivirus_mock_wp_remote_response;
+
+	$antivirus_mock_wp_remote_response[] = array(
+		$url_matcher,
+		$arg_matcher,
+		$result
+	);
+}
+
+/**
+ * Clear captured requests.
+ */
+function clear_wp_remote_post_request() {
+	global $antivirus_mock_wp_remote_requests;
+
+	$antivirus_mock_wp_remote_requests = array();
+}
+
+/**
+ * Clear mocked responses.
+ */
+function clear_wp_remote_post_response() {
+	global $antivirus_mock_wp_remote_response;
+
+	$antivirus_mock_wp_remote_response = array();
+}
+
+/**
+ * Get captured request from wp_remote_post calls.
+ *
+ * @param integer $offset Offset to return. If 0 (default) the latest is returned, 1 the before-latest, etc.
+ *
+ * @return array Array of requested URL and arguments.
+ */
+function get_wp_remote_post_request( $offset = 0 ) {
+	global $antivirus_mock_wp_remote_requests;
+
+	if ( count( $antivirus_mock_wp_remote_requests ) <= $offset ) {
+		return null;
+	} else {
+		return $antivirus_mock_wp_remote_requests[ count( $antivirus_mock_wp_remote_requests ) - 1 - $offset ];
+	}
+}
+
+/**
+ * Get captured mails from wp_mail calls.
+ *
+ * @param integer $offset Offset to return. If 0 (default) the latest is returned, 1 the before-latest, etc.
+ *
+ * @return array Array of recipient, subject, message and headers.
+ */
+function get_wp_mail( $offset = 0 ) {
+	global $antivirus_mock_wp_mail_capture;
+
+	if ( count( $antivirus_mock_wp_mail_capture ) <= $offset ) {
+		return null;
+	} else {
+		return $antivirus_mock_wp_mail_capture[ count( $antivirus_mock_wp_mail_capture ) - 1 - $offset ];
+	}
+}
+
+
+/*
+ * Mock the wp_remote_post() functkion to intercept POST requests.
+ */
+$antivirus_mock_wp_remote_post = 'global $antivirus_mock_wp_remote_requests;
+global $antivirus_mock_wp_remote_response;
+
+$antivirus_mock_wp_remote_requests[] = array( $url, $args );
+
+$response = new WP_Error();
+foreach ( $antivirus_mock_wp_remote_response as $r ) {
+	if ( ( empty( $r[0] ) || preg_match( $r[0], $url ) ) ||
+	     ( empty( $r[1] ) || $r[1]( $args ) ) ) {
+		$response = $r[2];
+	}
+}
+
+return $response;';
+
+/*
+ * Mock the wp_mail() function to intercept outgoing mails.
+ */
+$antivirus_mock_wp_mail = 'global $antivirus_mock_wp_mail_capture;
+
+$antivirus_mock_wp_mail_capture[] = array(
+	$to,
+	$subject,
+	$message,
+	$headers,
+);
+
+return true;
+';
+
+if ( function_exists( 'runkit7_function_redefine' ) ) {
+	runkit7_function_redefine( 'wp_remote_post', '$url, $args = array()', $antivirus_mock_wp_remote_post );
+	runkit7_function_redefine( 'wp_mail', '$to, $subject, $message, $headers = \'\', $attachments = array()', $antivirus_mock_wp_mail );
+} elseif ( function_exists( 'runkit_function_redefine' ) ) {
+	runkit_function_redefine( 'wp_remote_post', '$url, $args = array()', $antivirus_mock_wp_remote_post );
+	runkit_function_redefine( 'wp_mail', '$to, $subject, $message, $headers = \'\', $attachments = array()', $antivirus_mock_wp_mail );
+} else {
+	throw new Exception( 'runkit extension not installed' );
+}


### PR DESCRIPTION
To overcome the rate limitations of the hard-coded API key I've added an option to provide a custom key.

If the key is given, i.e. is not empty, it is used instead of the default. However the fixed key is still available as fallback.

As there's a risk of misconfiguration now, because the key may be invalid or expired I've also split the response handling. There's an open **TODO** in handling the error cases.

**Old:**
* status 200 and empty body
  * OK
* otherwise
  * send warning

**New:**
* status 200
  * empty body
    * OK
  * non-empty body
    * send warning
* status 400/403
  * invalid key, asssuming the request itself is not messed up
    * send notification, including an advice to solve the problem (check the custom key if provided or provide one otherwise)
* otherwise (likely status 5xx)
  * an error occured during request (TODO)

Although you might expect a 403 from an invalid code[1], I've seen a 400 with an arbitrary invalid key (i.e. "foobar") and message "Invalid API key ..." in the JSON body.


[1] https://developers.google.com/safe-browsing/v4/status-codes