### PR TITLE
Change file path to enqueue JavaScript and CSS properly

### DIFF
--- a/antivirus.php
+++ b/antivirus.php
@@ -37,6 +37,8 @@ if ( ! class_exists( 'WP' ) ) {
 	die();
 }
 
+define( 'ANTIVIRUS_FILE', __FILE__ );
+
 /**
  * Plugin autoloader.
  *

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -312,7 +312,7 @@ class AntiVirus {
 		// Enqueue the JavaScript.
 		wp_enqueue_script(
 			'av_script',
-			plugins_url( 'js/script.min.js', __FILE__ ),
+			plugins_url( 'js/script.min.js', dirname( __FILE__ ) ),
 			array( 'jquery' ),
 			$data['Version']
 		);
@@ -341,7 +341,7 @@ class AntiVirus {
 		// Enqueue the stylesheet.
 		wp_enqueue_style(
 			'av_css',
-			plugins_url( 'css/style.min.css', __FILE__ ),
+			plugins_url( 'css/style.min.css', dirname( __FILE__ ) ),
 			array(),
 			$data['Version']
 		);

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -45,7 +45,7 @@ class AntiVirus {
 		}
 
 		// Save the plugin basename.
-		self::$base = plugin_basename( __FILE__ );
+		self::$base = plugin_basename( ANTIVIRUS_FILE );
 
 		// Run the daily cronjob.
 		if ( defined( 'DOING_CRON' ) ) {
@@ -307,12 +307,12 @@ class AntiVirus {
 	 */
 	public static function add_enqueue_script() {
 		// Get plugin data.
-		$data = get_plugin_data( __FILE__ );
+		$data = get_plugin_data( ANTIVIRUS_FILE );
 
 		// Enqueue the JavaScript.
 		wp_enqueue_script(
 			'av_script',
-			plugins_url( 'js/script.min.js', dirname( __FILE__ ) ),
+			plugins_url( 'js/script.min.js', ANTIVIRUS_FILE ),
 			array( 'jquery' ),
 			$data['Version']
 		);
@@ -336,12 +336,12 @@ class AntiVirus {
 	 */
 	public static function add_enqueue_style() {
 		// Get plugin data.
-		$data = get_plugin_data( __FILE__ );
+		$data = get_plugin_data( ANTIVIRUS_FILE );
 
 		// Enqueue the stylesheet.
 		wp_enqueue_style(
 			'av_css',
-			plugins_url( 'css/style.min.css', dirname( __FILE__ ) ),
+			plugins_url( 'css/style.min.css', ANTIVIRUS_FILE ),
 			array(),
 			$data['Version']
 		);


### PR DESCRIPTION
Fixes issue #57.

[Function Reference](https://codex.wordpress.org/Function_Reference/plugins_url#Common_Usage) mentions, that 

> If you are using the plugins_url() function in a file that is nested inside a subdirectory of your plugin directory, you should use PHP's dirname() function…

Changing file path enqueues JavaScript and CSS properly.