### PR TITLE
Scan files of parent theme if a child theme is active (#1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ### unreleased ###
 * **English**
 	 * Option to provide a custom key for the Google Safe Browsing API
+	 * Scan files of parent theme if a child theme is active
 * **Deutsch**
 	* Möglichkeit einen eigenen Schlüssel für die Google Safe Browsing API zu verwenden
+	* Dateien des Parent Themes scannen, falls ein Child Theme aktiv ist
 
 
 ### 1.3.10 ###

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 	 * Scan files of parent theme if a child theme is active
 * **Deutsch**
 	* Möglichkeit einen eigenen Schlüssel für die Google Safe Browsing API zu verwenden
-	* Dateien des Parent Themes scannen, falls ein Child Theme aktiv ist
+	* Dateien des übergeordneten Themes scannen, falls ein Child-Theme aktiv ist
 
 
 ### 1.3.10 ###

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -354,11 +354,12 @@ class AntiVirus {
 	 *
 	 * @return array|false An array holding the theme data or false on failure.
 	 *
-	 * @since 1.4 Added $t parameter.
+	 * @since 1.4 Added $theme parameter.
 	 */
-	private static function _get_current_theme( $theme = false ) {
-		if ( false === $theme ) {
-			$theme = wp_get_theme();
+	private static function _get_theme_data( $theme ) {
+		// Break recursion if no valid (parent) theme is given.
+		if ( ! $theme ) {
+			return false;
 		}
 
 		// Extract data.
@@ -366,17 +367,8 @@ class AntiVirus {
 		$slug  = $theme->get_stylesheet();
 		$files = $theme->get_files( 'php', 1 );
 
-		// Check if empty.
-		if ( empty( $name ) || empty( $files ) ) {
-			return false;
-		}
-
 		// Append parent's data, if we got a child theme.
-		if ( false !== $theme->parent() ) {
-			$parent = self::_get_current_theme( $theme->parent() );
-		} else {
-			$parent = false;
-		}
+		$parent = self::_get_theme_data( $theme->parent() );
 
 		// Return false if there are no files in current theme and no parent.
 		if ( empty( $files ) && ! $parent ) {
@@ -398,7 +390,7 @@ class AntiVirus {
 	 */
 	protected static function _get_theme_files() {
 		// Check if the theme exists.
-		if ( ! $theme = self::_get_current_theme() ) {
+		if ( ! $theme = self::_get_theme_data(  wp_get_theme() ) ) {
 			return false;
 		}
 
@@ -442,7 +434,7 @@ class AntiVirus {
 	 * @return string|false The theme name or false on failure.
 	 */
 	private static function _get_theme_name() {
-		if ( $theme = self::_get_current_theme() ) {
+		if ( $theme = self::_get_theme_data(  wp_get_theme() ) ) {
 			if ( ! empty( $theme['Slug'] ) ) {
 				return $theme['Slug'];
 			}

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -350,16 +350,14 @@ class AntiVirus {
 	/**
 	 * Get the currently activated theme.
 	 *
-	 * @param WP_Theme|false $t Theme to parse.
+	 * @param WP_Theme|false $theme Theme to parse.
 	 *
 	 * @return array|false An array holding the theme data or false on failure.
 	 *
 	 * @since 1.4 Added $t parameter.
 	 */
-	private static function _get_current_theme( $t = false ) {
-		if ( $t ) {
-			$theme = $t;
-		} else {
+	private static function _get_current_theme( $theme = false ) {
+		if ( false === $theme ) {
 			$theme = wp_get_theme();
 		}
 

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -350,10 +350,20 @@ class AntiVirus {
 	/**
 	 * Get the currently activated theme.
 	 *
+	 * @param WP_Theme|false $t Theme to parse.
+	 *
 	 * @return array|false An array holding the theme data or false on failure.
+	 *
+	 * @since 1.4 Added $t parameter.
 	 */
-	private static function _get_current_theme() {
-		$theme = wp_get_theme();
+	private static function _get_current_theme( $t = false ) {
+		if ( $t ) {
+			$theme = $t;
+		} else {
+			$theme = wp_get_theme();
+		}
+
+		// Extract data.
 		$name  = $theme->get( 'Name' );
 		$slug  = $theme->get_stylesheet();
 		$files = $theme->get_files( 'php', 1 );
@@ -363,10 +373,23 @@ class AntiVirus {
 			return false;
 		}
 
+		// Append parent's data, if we got a child theme.
+		if ( false !== $theme->parent() ) {
+			$parent = self::_get_current_theme( $theme->parent() );
+		} else {
+			$parent = false;
+		}
+
+		// Return false if there are no files in current theme and no parent.
+		if ( empty( $files ) && ! $parent ) {
+			return false;
+		}
+
 		return array(
 			'Name'           => $name,
 			'Slug'           => $slug,
 			'Template Files' => $files,
+			'Parent'         => $parent,
 		);
 	}
 
@@ -381,8 +404,17 @@ class AntiVirus {
 			return false;
 		}
 
+		$files = $theme['Template Files'];
+
+		// Append parent files, if available.
+		$parent = $theme['Parent'];
+		while ( false !== $parent ) {
+			$files  = array_merge( $files, $parent['Template Files'] );
+			$parent = $parent['Parent'];
+		}
+
 		// Check its files.
-		if ( empty( $theme['Template Files'] ) ) {
+		if ( empty( $files ) ) {
 			return false;
 		}
 
@@ -390,7 +422,7 @@ class AntiVirus {
 		return array_unique(
 			array_map(
 				array( 'AntiVirus', '_strip_content_dir' ),
-				$theme['Template Files']
+				$files
 			)
 		);
 	}


### PR DESCRIPTION
The title tells the whole story. (resolves #1)

I've added a trivial recursion while `$theme->parent()` provides a valid theme in the `_get_current_theme()` method. `false` is only returned if the current theme and the parent theme is empty (probably never happens), but empty child themes (i.e. only CSS changes) are likely to be found in the wild.

Later in the `_get_theme_files()` phase the file arrays are flattened.