### PR TITLE
fix transparency report link

### DIFF
--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -713,7 +713,7 @@ class AntiVirus {
 									echo wp_kses(
 										/* translators: First placeholder (%s) starting link tag to transparency report, second placeholder closing link tag */
 										sprintf( __( 'Diagnosis and notification in suspicion case. For more details read %1$s the transparency report %2$s.', 'antivirus' ), $start_tag, $end_tag ),
-										array( 'a' => array( 'href' ) )
+										array( 'a' => array( 'href' => array() ) )
 									);
 									?>
 								</p>


### PR DESCRIPTION
The ` wp_kses`  arguments removed the `href`  attribute from the "the transparency report" on the settings page.