### PR TITLE
Deprecate pseudo-constructor and add init() method

### DIFF
--- a/antivirus.php
+++ b/antivirus.php
@@ -63,7 +63,7 @@ spl_autoload_register( 'antivirus_autoload' );
 
 
 // Initialize the plugin.
-add_action( 'plugins_loaded', array( 'AntiVirus', 'instance' ), 99 );
+add_action( 'plugins_loaded', array( 'AntiVirus', 'init' ), 99 );
 
 /* Hooks */
 register_activation_hook( __FILE__, array( 'AntiVirus', 'activation' ) );

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -22,19 +22,20 @@ class AntiVirus {
 
 	/**
 	 * Pseudo constructor.
+	 *
+	 * @deprecated Since 1.4, use init() instead.
+	 * @see AntiVirus::init()
 	 */
 	public static function instance() {
-		new self();
+		self::init();
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the plugin.
 	 *
-	 * Should not be called directly,
-	 *
-	 * @see AntiVirus::instance()
+	 * @since 1.4
 	 */
-	public function __construct() {
+	public static function init() {
 		// Don't run during autosave or XML-RPC request.
 		if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) ) {
 			return;
@@ -59,6 +60,19 @@ class AntiVirus {
 				add_action( 'plugin_action_links_' . self::$base, array( __CLASS__, 'init_action_links' ) );
 			}
 		}
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * Should not be called directly,
+	 *
+	 * @deprecated Since 1.4, use init() instead.
+	 * @see AntiVirus::init()
+	 */
+	public function __construct() {
+		// Nothing to construct, just run the initialization for backwards compatibility.
+		self::init();
 	}
 
 	/**

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -37,7 +37,7 @@ class AntiVirus_Test_Plugin extends AntiVirus_TestCase {
 		WP_Mock::expectActionNotAdded( 'admin_notices', array( AntiVirus::class, 'show_dashboard_notice' ) );
 		WP_Mock::expectActionNotAdded( 'plugin_row_meta', array( AntiVirus::class, 'init_row_meta' ) );
 		WP_Mock::expectActionNotAdded( 'plugin_action_links_antivirus.php', array( AntiVirus::class, 'init_action_links' ) );
-		new AntiVirus();
+		AntiVirus::init();
 		self::assertTrue( true );
 	}
 
@@ -53,7 +53,7 @@ class AntiVirus_Test_Plugin extends AntiVirus_TestCase {
 		WP_Mock::expectActionAdded( 'deactivate_antivirus.php', array( AntiVirus::class, 'clear_scheduled_hook' ) );
 		WP_Mock::expectActionAdded( 'plugin_row_meta', array( AntiVirus::class, 'init_row_meta' ), 10, 2 );
 		WP_Mock::expectActionAdded( 'plugin_action_links_antivirus.php', array( AntiVirus::class, 'init_action_links' ) );
-		new AntiVirus();
+		AntiVirus::init();
 		self::assertTrue( true );
 	}
 
@@ -70,7 +70,7 @@ class AntiVirus_Test_Plugin extends AntiVirus_TestCase {
 		WP_Mock::expectActionNotAdded( 'deactivate_antivirus.php', array( AntiVirus::class, 'clear_scheduled_hook' ) );
 		WP_Mock::expectActionNotAdded( 'plugin_row_meta', array( AntiVirus::class, 'init_row_meta' ) );
 		WP_Mock::expectActionNotAdded( 'plugin_action_links_antivirus.php', array( AntiVirus::class, 'init_action_links' ) );
-		new AntiVirus();
+		AntiVirus::init();
 		self::assertTrue( true );
 	}
 


### PR DESCRIPTION
The constructor only does static initialization. The ` instance()`  method indicates some kind of singleton pattern, but actually only triggers the constructor without returning anything.

Deprecate both in favor of a semantically more precise ` init()` method.