### PR TITLE
Fix declaration of WP compatiblity of AntiVirus 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 * Contributors:      pluginkollektiv
 * Tags:              antivirus, malware, scanner, phishing, safe browsing, vulnerability
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
-* Requires at least: 3.8
+* Requires at least: 4.6
 * Requires PHP:      5.2
 * Tested up to:      5.6
 * Stable tag:        1.4.0

--- a/README.md
+++ b/README.md
@@ -40,12 +40,6 @@ In case your WordPress site has been hacked, *AntiVirus* will help you to become
 * Author: [Sergej Müller](https://sergejmueller.github.io/)
 * Maintainers: [pluginkollektiv](http://pluginkollektiv.org/)
 
-## Installation ##
-* If you don’t know how to install a plugin for WordPress, [here’s how](https://codex.wordpress.org/Managing_Plugins#Installing_Plugins).
-
-### Requirements ###
-* PHP 5.2.4 or greater
-* WordPress 3.8 or greater
 
 ## Frequently Asked Questions ##
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,6 +11,7 @@
 	<file>tests</file>
 
     <!-- Extend from WPCS ruleset -->
+	<config name="minimum_supported_wp_version" value="4.6"/>
     <rule ref="WordPress"/>
 
 	<!-- Verify i18n text domain -->


### PR DESCRIPTION
AntiVirus 1.4.0 is only compatible with WordPress 4.6+ due to the missing call to `load_plugin_textdomain` (wp. [Plugin Handbook](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#loading-text-domain)).

This PR fixes the declaration in the README and adds a WP compatibility check to the README.