### PR TITLE
Fix README and some translation strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ In case your WordPress site has been hacked, *AntiVirus* will help you to become
 * Scan for suspicious code in the theme files (daily scan with email notifications and manual scan) with an option to mark detected cases as false positive
 * Checksum verification for WordPress Core files
 * Optional: Google Safe Browsing for malware and phishing monitoring.
-* Cleaning up after plugin removal
 
 A complete documentation is available on the [AntiVirus website](https://antivirus.pluginkollektiv.org/documentation/).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 * Contributors:      pluginkollektiv
 * Tags:              antivirus, malware, scanner, phishing, safe browsing, vulnerability
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
-* Requires at least: 3.8
+* Requires at least: 4.6
 * Requires PHP:      5.2
 * Tested up to:      5.6
 * Stable tag:        1.4.0
@@ -12,19 +12,18 @@
 Security plugin to protect your blog or website against exploits and spam injections.
 
 ## Description ##
-*AntiVirus for WordPress* is a easy-to-use, safe tool to harden your WordPress site against exploits, malware and spam injections.
-You can configure *AntiVirus* to perform an automated daily scan of your theme files. If the plugin happens to detect any suspicious code injections, it will send out a notification to a previously configured e-mail address.
+*AntiVirus* is an easy-to-use, safe tool to harden your WordPress site against exploits, malware and spam injections.
+You can configure *AntiVirus* to perform an automated daily scan of your theme files. If the plugin detects any suspicious code injections, it will send out a notification to a previously configured e-mail address.
 
 In case your WordPress site has been hacked, *AntiVirus* will help you to become aware of the problem very quickly in order for you to take immediate action.
 
 ### Features ###
-* Virus alert in the admin bar
-* Cleaning up after plugin removal
-* Daily scan with email notifications
-* Theme template checks
-* Whitelist solution: Mark suspected cases as "no virus"
-* Manual check of template files with alerts on suspected cases
+* Scan for suspicious code in the theme files (daily scan with email notifications and manual scan) with an option to mark detected cases as false positive
+* Checksum verification for WordPress Core files
 * Optional: Google Safe Browsing for malware and phishing monitoring.
+* Cleaning up after plugin removal
+
+A complete documentation is available on the [AntiVirus website](https://antivirus.pluginkollektiv.org/documentation/).
 
 ### Support ###
 * Community support via the [support forums on wordpress.org](https://wordpress.org/support/plugin/antivirus)
@@ -38,21 +37,8 @@ In case your WordPress site has been hacked, *AntiVirus* will help you to become
 
 ### Credits ###
 * Author: [Sergej Müller](https://sergejmueller.github.io/)
-* Maintainers: [pluginkollektiv](http://pluginkollektiv.org/)
+* Maintainers: [pluginkollektiv](https://pluginkollektiv.org)
 
-## Installation ##
-* If you don’t know how to install a plugin for WordPress, [here’s how](https://codex.wordpress.org/Managing_Plugins#Installing_Plugins).
-
-### Requirements ###
-* PHP 5.2.4 or greater
-* WordPress 3.8 or greater
-
-## Frequently Asked Questions ##
-
-### Will AntiVirus protect my site from being hacked? ###
-Not literally "protect from". The plugin’s purpose is to *detect* any "hack" that has already happened and enable you to take immediate action upon it.
-
-A complete documentation is available on the [AntiVirus website](https://antivirus.pluginkollektiv.org/documentation/).
 
 ## Changelog ##
 

--- a/antivirus.php
+++ b/antivirus.php
@@ -10,8 +10,6 @@
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  * Version:     1.4.0
  *
- * [](http://coderisk.com/wp/plugin/antivirus/RIPS-x1EDAuZC-C)
- *
  * @package AntiVirus
  */
 

--- a/inc/class-antivirus-checksumverifier.php
+++ b/inc/class-antivirus-checksumverifier.php
@@ -36,7 +36,7 @@ class AntiVirus_ChecksumVerifier extends AntiVirus {
 				esc_html__( 'Checksum Verifier Alert', 'antivirus' ),
 				sprintf(
 					"%s:\r\n\r\n- %s",
-					esc_html__( 'Official checksums do not match for the following files', 'antivirus' ),
+					esc_html__( 'Checksums do not match for the following files', 'antivirus' ),
 					implode( "\r\n- ", $matches )
 				)
 			);

--- a/inc/class-antivirus-safebrowsing.php
+++ b/inc/class-antivirus-safebrowsing.php
@@ -92,8 +92,8 @@ class AntiVirus_SafeBrowsing extends AntiVirus {
 			// Invalid request (most likely invalid key) or expired/exceeded key.
 			$mail_body = sprintf(
 				"%s\r\n\r\n%s",
-				esc_html__( 'Checking yout site against the Google Safe Browsing API has failed.', 'antivirus' ),
-				esc_html__( 'This does not mean that your site has been infected, but that the status could not be determinined.', 'antivirus' )
+				esc_html__( 'Checking your site against the Google Safe Browsing API has failed.', 'antivirus' ),
+				esc_html__( 'This does not mean that your site has been infected, but that the status could not be determined.', 'antivirus' )
 			);
 
 			// Add (sanitized) error message, if available.
@@ -109,12 +109,12 @@ class AntiVirus_SafeBrowsing extends AntiVirus {
 			if ( $custom_key ) {
 				$mail_body .= sprintf(
 					"\r\n%s",
-					esc_html__( 'Please check if your API key is correct and its limit not exceeded. If everything is correct and the error persists for the next requests, please contact the Plugin support.', 'antivirus' )
+					esc_html__( 'Please check if your API key is correct and its limit not exceeded. If everything is correct and the error persists for the next requests, please contact the plugin support.', 'antivirus' )
 				);
 			} else {
 				$mail_body .= sprintf(
 					"\r\n%s",
-					esc_html__( 'This might be due to an exceeded rate limit on the shared API key. To ensure this does not happen please consider providing your own key using the Plugin settings page.', 'antivirus' )
+					esc_html__( 'This might be due to an exceeded rate limit on the shared API key. To ensure this does not happen please provide your own key using the settings page.', 'antivirus' )
 				);
 			}
 

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -719,12 +719,12 @@ class AntiVirus {
 
 								<p class="description">
 									<?php
-									/* translators: Link for transparency report in english */
+									/* translators: Link for transparency report */
 									$start_tag = sprintf( '<a href="%s">', esc_attr__( 'https://transparencyreport.google.com/safe-browsing/search?hl=en', 'antivirus' ) );
 									$end_tag = '</a>';
 									echo wp_kses(
-										/* translators: First placeholder (%s) starting link tag to transparency report, second placeholder closing link tag */
-										sprintf( __( 'Diagnosis and notification in suspicion case. For more details read %1$s the transparency report %2$s.', 'antivirus' ), $start_tag, $end_tag ),
+										/* translators: First placeholder (%1$s) starting link tag to transparency report, second placeholder (%2$s) closing link tag */
+										sprintf( __( 'Diagnosis and notification in suspicion case. For more details read %1$sthe transparency report%2$s.', 'antivirus' ), $start_tag, $end_tag ),
 										array( 'a' => array( 'href' => array() ) )
 									);
 									?>
@@ -752,13 +752,11 @@ class AntiVirus {
 								<label for="av_checksum_verifier">
 									<input type="checkbox" name="av_checksum_verifier" id="av_checksum_verifier"
 										   value="1" <?php checked( self::_get_option( 'checksum_verifier' ), 1 ); ?> />
-									<?php esc_html_e( 'Checksum verification of WP core files', 'antivirus' ); ?>
+									<?php esc_html_e( 'Checksum verification of WordPress core files', 'antivirus' ); ?>
 								</label>
 
 								<p class="description">
-									<?php
-									esc_html_e( 'Matches checksums of all WordPress core files against the values provided by the official API.', 'antivirus' );
-									?>
+									<?php esc_html_e( 'Matches checksums of all WordPress core files against the values provided by the official API.', 'antivirus' ); ?>
 								</p>
 							</fieldset>
 
@@ -772,7 +770,7 @@ class AntiVirus {
 									   placeholder="<?php esc_attr_e( 'Email address for notifications', 'antivirus' ); ?>" />
 
 								<p class="description">
-									<?php esc_html_e( 'If the field is empty, the blog admin will be notified', 'antivirus' ); ?>
+									<?php esc_html_e( 'If the field is empty, the blog admin will be notified.', 'antivirus' ); ?>
 								</p>
 							</fieldset>
 						</td>
@@ -788,14 +786,6 @@ class AntiVirus {
 								'<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
 								'https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW',
 								esc_html__( 'Donate', 'antivirus' )
-							);
-							?>
-							&bull;
-							<?php
-							printf(
-								'<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
-								esc_attr__( 'https://wordpress.org/plugins/antivirus/faq/', 'antivirus' ),
-								esc_html__( 'FAQ', 'antivirus' )
 							);
 							?>
 							&bull;

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0"?>
 <ruleset name="AntiVirus">
-    <description>Sniffs for the coding standards of the plugin</description>
+	<description>Sniffs for the coding standards of the plugin</description>
 
-    <arg value="psvn"/>
-    <arg name="colors"/>
+	<arg value="psvn"/>
+	<arg name="colors"/>
 
-    <!-- Files to sniff -->
-    <file>antivirus.php</file>
-    <file>inc</file>
+	<!-- Files to sniff -->
+	<file>antivirus.php</file>
+	<file>inc</file>
 	<file>tests</file>
 
-    <!-- Extend from WPCS ruleset -->
-    <rule ref="WordPress"/>
+	<!-- Extend from WPCS ruleset -->
+	<config name="minimum_supported_wp_version" value="4.6"/>
+	<rule ref="WordPress"/>
 
 	<!-- Verify i18n text domain -->
 	<rule ref="WordPress.WP.I18n">
@@ -25,9 +26,9 @@
 		<exclude-pattern>tests</exclude-pattern>
 	</rule>
 
-    <!-- PHP compatibility level -->
-    <config name="testVersion" value="5.2-"/>
-    <rule ref="PHPCompatibility">
+	<!-- PHP compatibility level -->
+	<config name="testVersion" value="5.2-"/>
+	<rule ref="PHPCompatibility">
 		<exclude-pattern>tests</exclude-pattern>
 	</rule>
 </ruleset>


### PR DESCRIPTION
1. Simplify the description in the README (including the changes from #84 merged into stable)
2. Remove coderisk link from main plugin file
3. Fix some translation strings which contain spelling mistakes or are inconsistent
4. Remove FAQ section in the README and the link to the FAQ on the settings page (everything should be in the documentation now, the only question should be answered in the normal text now)

(Change 2 has been pushed to the 1.4.0 tag on SVN manually to trigger the import of the files after merging #84.)