### PR TITLE
fix theme file collection for duplicate names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### unreleased ###
+
+* **English**
+	* Some spelling and translation corrections
+	* Fixed theme file collection for child themes with duplicate names
+* **Deutsch**
+	* Einige Rechtschreib- und Übersetzungsfehler korrigiert
+	* Sammlung von Theme Dateien für Child Themes mit doppelten Dateinamen korrigiert
+
+
 ### 1.4.0 ###
 * **English**
 	 * Option to provide a custom key for the Google Safe Browsing API

--- a/inc/class-antivirus-checkinternals.php
+++ b/inc/class-antivirus-checkinternals.php
@@ -165,7 +165,7 @@ class AntiVirus_CheckInternals extends AntiVirus {
 	 *
 	 * @return array|bool An array of matched lines or false on failure.
 	 */
-	private static function _check_file_line( $line = '', $num ) {
+	private static function _check_file_line( $line, $num ) {
 		// Trim value.
 		$line = trim( (string) $line );
 

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -393,7 +393,7 @@ class AntiVirus {
 		// Extract data.
 		$name  = $theme->get( 'Name' );
 		$slug  = $theme->get_stylesheet();
-		$files = $theme->get_files( 'php', 1 );
+		$files = array_values( $theme->get_files( 'php', 1 ) );
 
 		// Append parent's data, if we got a child theme.
 		$parent = self::_get_theme_data( $theme->parent() );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,7 +8,92 @@
 // phpcs:ignore Squiz.Commenting.FileComment.Missing
 require_once __DIR__ . '/../vendor/autoload.php';
 
+// Override WP_CONTENT_DIR to use own resources instead of WP_Mock dummy files.
+define( 'WP_CONTENT_DIR', __DIR__ . '/resources' );
+
 WP_Mock::bootstrap();
 
 require_once __DIR__ . '/antivirustestcase.php';
 require_once __DIR__ . '/../inc/class-antivirus.php';
+
+/**
+ * Class WP_Theme_Mock.
+ *
+ * Mock-implementation of {@link WP_Theme}.
+ */
+class WP_Theme_Mock {
+	/**
+	 * Theme data.
+	 *
+	 * @var array
+	 */
+	private $data;
+
+	/**
+	 * WP_Theme_Mock constructor.
+	 *
+	 * @param string             $name       Theme name.
+	 * @param string             $stylesheet Theme stylesheet name.
+	 * @param array              $files      Theme files.
+	 * @param WP_Theme_Mock|null $parent     Parent theme (optional).
+	 */
+	public function __construct( string $name, string $stylesheet, array $files, WP_Theme_Mock $parent = null ) {
+		$this->data = array(
+			'Name'       => $name,
+			'stylesheet' => $stylesheet,
+			'files'      => $files,
+			'parent'     => $parent ?? false,
+		);
+	}
+
+	/**
+	 * Get theme attribute.
+	 *
+	 * @param string $key Attribute key.
+	 *
+	 * @return mixed Attribute value.
+	 */
+	public function get( string $key ) {
+		return $this->data[ $key ] ?? false;
+	}
+
+	/**
+	 * Set theme attribute.
+	 *
+	 * @param string $key Attribute key.
+	 * @param mixed  $val Attribute value.
+	 */
+	public function set( string $key, $val ): void {
+		$this->data[ $key ] = $val;
+	}
+
+	/**
+	 * Get stylesheet name.
+	 *
+	 * @return string Stylesheet name.
+	 */
+	public function get_stylesheet(): string {
+		return $this->get( 'stylesheet' );
+	}
+
+	/**
+	 * Get theme files.
+	 *
+	 * @param string $suffix File suffix (ignored here).
+	 * @param int    $deptn  File hierarchy depth (ignored here).
+	 *
+	 * @return false|mixed
+	 */
+	public function get_files( string $suffix, int $deptn ) {
+		return $this->get( 'files' );
+	}
+
+	/**
+	 * Get parent theme.
+	 *
+	 * @return false|WP_Theme_Mock Parent theme or false.
+	 */
+	public function parent() {
+		return $this->get( 'parent' );
+	}
+}

--- a/tests/resources/themes/theme1/themefile1
+++ b/tests/resources/themes/theme1/themefile1
@@ -1,0 +1,1 @@
+test content 1

--- a/tests/resources/themes/theme1/themefile2
+++ b/tests/resources/themes/theme1/themefile2
@@ -1,0 +1,1 @@
+test content 2

--- a/tests/resources/themes/theme2/themefile1
+++ b/tests/resources/themes/theme2/themefile1
@@ -1,0 +1,1 @@
+testcontent 1a

--- a/tests/resources/themes/theme2/themefile3
+++ b/tests/resources/themes/theme2/themefile3
@@ -1,0 +1,1 @@
+testcontent 3

--- a/tests/test-checkinternals.php
+++ b/tests/test-checkinternals.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Test our plugin.
+ *
+ * @package AntiVirus
+ */
+
+/**
+ * Class AntiVirus_Checkinternals_Test.
+ *
+ * Unit tests for the the {@link AntiVirus_CheckInternals} module.
+ */
+class AntiVirus_Checkinternals_Test extends AntiVirus_TestCase {
+
+	/**
+	 * Set up test.
+	 *
+	 * @inheritdoc
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		require_once __DIR__ . '/../inc/class-antivirus-checkinternals.php';
+	}
+
+	/**
+	 * Test theme file checks.
+	 */
+	public function test_theme_files(): void {
+		$theme = new WP_Theme_Mock(
+			'Theme 1',
+			'theme1',
+			array(
+				'themefile1' => '/themes/theme1/themefile1',
+				'themefile2' => '/themes/theme1/themefile2',
+			)
+		);
+		$parent_theme = new WP_Theme_Mock(
+			'Theme 2',
+			'theme2',
+			array(
+				'themefile1' => '/themes/theme2/themefile1',
+				'themefile3' => '/themes/theme2/themefile3',
+			)
+		);
+
+		$checked_files = array();
+		WP_Mock::userFunction( 'wp_get_theme' )
+				->andReturn( $theme );
+		WP_Mock::userFunction( 'validate_file' )
+				->andReturnUsing(
+					function ( $file ) use ( &$checked_files ) {
+						$checked_files[] = $file;
+
+						return 0;
+					}
+				);
+
+		// Check standalone theme.
+		self::assertFalse( AntiVirus_CheckInternals::_check_theme_files(), 'failed checking empty files' );
+		self::assertEquals( 2, count( $checked_files ), 'unexpected number of checked files for standlone theme' );
+
+		// Again with child theme.
+		$theme->set( 'parent', $parent_theme );
+		$checked_files = array();
+		self::assertFalse( AntiVirus_CheckInternals::_check_theme_files(), 'failed checking empty files' );
+		self::assertEquals( 4, count( $checked_files ), 'unexpected number of checked files for child theme' );
+
+		// TODO: add some real content checks.
+	}
+}


### PR DESCRIPTION
Part of reported regressions in the WP support forums: https://wordpress.org/support/topic/virus-alert-since-1-4-0/

`WP_Theme::get_files()` returns an associative array with the relative file path as key and the absolute path as value. For child themes with files matching the parent's relative paths, these got overwritten by `array_merge()`. We only process the absolute path, so now we strip
the values and use numeric indices which are not squashed.

**Example:**
```php
$child_files = array(
	'functions.php' => '/child/functions.php',
	'header.php'    => '/child/header.php',
);
$parent_files = array(
	'functions.php' => '/parent/functions.php',
	'footer.php'    => '/parent/header.php',
);

$all_files = array_merge( $child_files, $parent_files );
/*
 * array (size=3)
 *   'functions.php' => string '/parent/functions.php' (length=21)
 *   'header.php'    => string '/child/header.php' (length=17)
 *   'footer.php'    => string '/parent/footer.php' (length=18)
 */

$child_files  = array_values( $child_files );
$parent_files = array_values( $parent_files );
$all_files    = array_merge( $child_files, $parent_files );

/*
 * array (size=4)
 *   0 => string '/child/functions.php' (length=20)
 *   1 => string '/child/header.php' (length=17)
 *   2 => string '/parent/functions.php' (length=21)
 *   3 => string '/parent/footer.php' (length=18)
 */
```

I've added a unit test for the ` Antivirus_CheckInternals`  class which does not yet verify any content processing, but it covers the file collection.