### PR TITLE
fix file name sanitization for manual theme scan (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### unreleased ###
+
+* **English**
+	* Fixed file name sanitization in manual theme scan
+* **Deutsch**
+	* Bereinigung von Dateinamen beim manuellen Theme Scan korrigiert
+
+
 ### 1.4.0 ###
 * **English**
 	 * Option to provide a custom key for the Google Safe Browsing API

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -520,7 +520,7 @@ class AntiVirus {
 
 			case 'check_theme_file':
 				if ( ! empty( $_POST['_theme_file'] ) ) {
-					$theme_file = sanitize_file_name( wp_unslash( $_POST['_theme_file'] ) );
+					$theme_file = filter_var( wp_unslash( $_POST['_theme_file'] ), FILTER_SANITIZE_STRING );
 					$lines = AntiVirus_CheckInternals::check_theme_file( $theme_file );
 					if ( $lines ) {
 						foreach ( $lines as $num => $line ) {


### PR DESCRIPTION
`sanitize_file()` strips all directory separators from the file path that is passed via AJAX. We now simply sanitize the string, as the actual file path is validated during the process anyway.

fixes #88