### PR TITLE
Consider all levels in theme file check instead of one only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 	* Fixed file name sanitization in manual theme scan
 	* Some spelling and translation corrections
 	* Fixed theme file collection for child themes with duplicate names
+	* Consider all levels in theme file check instead of one only
 * **Deutsch**
 	* Einige Rechtschreib- und Übersetzungsfehler korrigiert
 	* Sammlung von Theme Dateien für Child Themes mit doppelten Dateinamen korrigiert
-	* Bereinigung von Dateinamen beim manuellen Theme Scan korrigiert
+	* Bereinigung von Dateinamen beim manuellen Theme-Scan korrigiert
+	* Berücksichtigung aller Level im Theme-Scan
 
 
 ### 1.4.0 ###

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -393,7 +393,7 @@ class AntiVirus {
 		// Extract data.
 		$name  = $theme->get( 'Name' );
 		$slug  = $theme->get_stylesheet();
-		$files = array_values( $theme->get_files( 'php', 1 ) );
+		$files = array_values( $theme->get_files( 'php', -1 ) );
 
 		// Append parent's data, if we got a child theme.
 		$parent = self::_get_theme_data( $theme->parent() );


### PR DESCRIPTION
Fixes #87. The current maximum of just one level is just removed such that all theme files of any depth are checked.