### PR TITLE
Support translations in old WordPress versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@
 	* Some spelling and translation corrections
 	* Fixed theme file collection for child themes with duplicate names
 	* Consider all levels in theme file check instead of one only
+	* Support translations in old WordPress versions
 * **Deutsch**
 	* Einige Rechtschreib- und Übersetzungsfehler korrigiert
 	* Sammlung von Theme Dateien für Child Themes mit doppelten Dateinamen korrigiert
 	* Bereinigung von Dateinamen beim manuellen Theme-Scan korrigiert
 	* Berücksichtigung aller Level im Theme-Scan
+	* Unterstützung für Übersetzungen in älteren WordPress-Versionen
 
 
 ### 1.4.0 ###

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 * Contributors:      pluginkollektiv
 * Tags:              antivirus, malware, scanner, phishing, safe browsing, vulnerability
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
-* Requires at least: 4.6
+* Requires at least: 4.1
 * Requires PHP:      5.2
 * Tested up to:      5.6
 * Stable tag:        1.4.0

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -44,6 +44,9 @@ class AntiVirus {
 		// Save the plugin basename.
 		self::$base = plugin_basename( ANTIVIRUS_FILE );
 
+		// Load translations. Required due to support for WP versions before 4.6.
+		load_plugin_textdomain( 'antivirus' );
+
 		// Register the daily cronjob.
 		add_action( 'antivirus_daily_cronjob', array( __CLASS__, 'do_daily_cronjob' ) );
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,7 +11,7 @@
 	<file>tests</file>
 
 	<!-- Extend from WPCS ruleset -->
-	<config name="minimum_supported_wp_version" value="4.6"/>
+	<config name="minimum_supported_wp_version" value="4.1"/>
 	<rule ref="WordPress"/>
 
 	<!-- Verify i18n text domain -->

--- a/tests/antivirustestcase.php
+++ b/tests/antivirustestcase.php
@@ -35,6 +35,7 @@ abstract class AntiVirus_TestCase extends WP_Mock\Tools\TestCase {
 	public function setUp(): void {
 		WP_Mock::setUp();
 
+		WP_Mock::passthruFunction( 'load_plugin_textdomain' );
 		WP_Mock::passthruFunction( 'wp_parse_args' );
 		WP_Mock::userFunction( 'get_option' )->with( 'antivirus' )->andReturnUsing(
 			function () {


### PR DESCRIPTION
- Add load_plugin_textdomain for support of WordPress versions before 4.5
- Declare compatibility with WordPress 4.1+