### PR TITLE
rework base64 pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### unreleased
 * Rework base64 detection pattern (#95)
+* Fix output sanitization for matches that contain slashes (#95)
 
 ### 1.4.1 ###
 * Fix some spelling mistakes and correct translations (#85)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### unreleased
+* Rework base64 detection pattern (#95)
+
 ### 1.4.1 ###
 * Fix some spelling mistakes and correct translations (#85)
 * Fix file name sanitization in manual theme scan causing errors to be not shown in the admin area (#88, #89)

--- a/inc/class-antivirus-checkinternals.php
+++ b/inc/class-antivirus-checkinternals.php
@@ -291,7 +291,7 @@ class AntiVirus_CheckInternals extends AntiVirus {
 		}
 
 		// Return tag if it's higher than the maximum.
-		if ( strlen( $tag ) > $max ) {
+		if ( strlen( $tag ) >= $max ) {
 			return $tag;
 		}
 
@@ -299,7 +299,7 @@ class AntiVirus_CheckInternals extends AntiVirus {
 		$left = round( ( $max - strlen( $tag ) ) / 2 );
 
 		// Quote regular expression characters.
-		$tag = preg_quote( $tag );
+		$tag = preg_quote( $tag, '/' );
 
 		// Shorten string on the right side.
 		$output = preg_replace(

--- a/inc/class-antivirus-checkinternals.php
+++ b/inc/class-antivirus-checkinternals.php
@@ -189,9 +189,9 @@ class AntiVirus_CheckInternals extends AntiVirus {
 			$results = $matches[1];
 		}
 
-		// Search for base64 encoded strings.
+		// Search for base64 encoded strings, non-empty and only ending with "=".
 		preg_match_all(
-			'/[\'\"\$\\ \/]*?([a-zA-Z0-9]{' . strlen( base64_encode( 'sergej + swetlana = love.' ) ) . ',})/', /* get length of my life ;) */
+			'/[\'\"\$\\ \/]*?((?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=))/',
 			$line,
 			$matches
 		);

--- a/tests/resources/themes/theme1/maliciousfile
+++ b/tests/resources/themes/theme1/maliciousfile
@@ -1,0 +1,8 @@
+// Previously false-positives for base64 check.
+$aThirtySixCharactersLongVariableName = 0;
+echo 'Oberdonaudampfschiffahrtsgesellschaft';
+
+// Previously undetected base64 strings.
+$base64 = "IQ==";	// "!"
+$base64 = 'cGx1Z2lua28vL2VrdGl2Cg==';	// "pluginko//ektiv"
+$base64 = 'MSAc9+vXHm1qkYNhtk/PJA=';	// random stuff

--- a/tests/test-checkinternals.php
+++ b/tests/test-checkinternals.php
@@ -66,6 +66,29 @@ class AntiVirus_Checkinternals_Test extends AntiVirus_TestCase {
 		self::assertFalse( AntiVirus_CheckInternals::_check_theme_files(), 'failed checking empty files' );
 		self::assertEquals( 4, count( $checked_files ), 'unexpected number of checked files for child theme' );
 
-		// TODO: add some real content checks.
+		// Test of malicious patterns are detected.
+		$theme->set( 'parent', false );
+		$theme->set( 'files', array( '/themes/theme1/maliciousfile' ) );
+
+		$results = AntiVirus_CheckInternals::_check_theme_files();
+		self::assertIsArray( $results, 'malicous file passed check' );
+		self::assertArrayHasKey( '/themes/theme1/maliciousfile', $results, 'malicious file not in result array' );
+		$results = $results['/themes/theme1/maliciousfile'];
+		self::assertEquals( 3, count( $results ), 'unexpected number of matches in malicious file' );
+		self::assertEquals(
+			array( '$base64 = "@span@IQ==@/span@";	// "!"' ),
+			$results[5],
+			'unexpected match for line 6'
+		);
+		self::assertEquals(
+			array( '$base64 = \'@span@cGx1Z2lua28vL2VrdGl2Cg==@/span@\';	// "pluginko//ektiv"' ),
+			$results[6],
+			'unexpected match for line 7'
+		);
+		self::assertEquals(
+			array( '$base64 = \'MSA@span@c9+vXHm1qkYNhtk/PJA=@/span@\';	// random stuff' ),
+			$results[7],
+			'unexpected match for line 8'
+		);
 	}
 }


### PR DESCRIPTION
The theme file scan has a check for base64 strings (or at least that's what the comment tells us):

https://github.com/pluginkollektiv/antivirus/blob/fbc3614eef1316c81546dcffedb794ada7e81097/inc/class-antivirus-checkinternals.php#L192-L197

No idea what's the actual use of the `strlen( base64_encode( ... ) )` gimmick, but this pattern effectively evaluates to `/[\'\"\$\\ \/]*?([a-zA-Z0-9]{36,})/`, so it matches arbitrary alphanumeric strings of at least 36 characters. But that's not necessarily [base64](https://en.wikipedia.org/wiki/Base64 "Wikipedia").

A short list of negative examples:
```php
// False-positives.
$aThirtySixCharactersLongVariableName = 0;
echo 'Oberdonaudampfschiffahrtsgesellschaft';

// Undetected base64 strings.
$base64 = "IQ==";                     // "!"
$base64 = 'cGx1Z2lua28vL2VrdGl2Cg=='; // "pluginko//ektiv"
$base64 = 'MSAc9+vXHm1qkYNhtk/PJA=';  // random stuff
```
(all 5 examples covered by a unit test)

The proposed pattern `/[\'\"\$\\ \/]*?((?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=))/` matches strings of any length >= 4 that only contain valid base64 characters (alphanumeric, + and /) and do end with either "=" or "==".

Technically the trailing "=" is not necessary, as there are valid base64 strings of length with `%4 == 0`, e.g. "Zm9v" (plain: "foo"). However they may lead to a lot of false positives. "echo" for example is valid base64 encoding of the string "yh". Obviously not very useful.

Along with this modification I've added the slash to the `preg_quote()`  call for output sanitization, because the `preg_replace()` otherwise failed in these cases.