### PR TITLE
drop recursive check for get_option() calls in theme check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### unreleased
+* Drop recursive check on option that failed in several scenarios
+
 ### 1.4.1 ###
 * Fix some spelling mistakes and correct translations (#85)
 * Fix file name sanitization in manual theme scan causing errors to be not shown in the admin area (#88, #89)

--- a/inc/class-antivirus-checkinternals.php
+++ b/inc/class-antivirus-checkinternals.php
@@ -225,18 +225,6 @@ class AntiVirus_CheckInternals extends AntiVirus {
 			$results = array_merge( $results, $matches[0] );
 		}
 
-		// Look for `get_option` calls.
-		preg_match(
-			'/get_option\s*\(\s*[\'"](.*?)[\'"]\s*\)/',
-			$line,
-			$matches
-		);
-
-		// Check option.
-		if ( $matches && $matches[1] && self::_check_file_line( get_option( $matches[1] ), $num ) ) {
-			array_push( $results, 'get_option' );
-		}
-
 		if ( $results ) {
 			// Remove duplicates.
 			$results = array_unique( $results );


### PR DESCRIPTION
closes #96

Antivirus looks for `get_option()` calls in theme files and executes a recursive iteration on the string representation of the value retrieved.

While the real use of this (old) check is unclear, there are several scenarios where the logic breaks our plugin. One is the broken iteration when the value is of array type (notice in 7.4, warning in 8.0). Another more severe problem might arise from options containing strings with
`"get_option( ... )"` calls itself, causing infinite recursion that ends up in a stack overflow.

Because of the dubious benefits, we drop this check completely for now.