### PR TITLE
only recurse on string values for options check (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### unreleased
+* Only recurse string values for options check (#96)
+
 ### 1.4.1 ###
 * Fix some spelling mistakes and correct translations (#85)
 * Fix file name sanitization in manual theme scan causing errors to be not shown in the admin area (#88, #89)

--- a/inc/class-antivirus-checkinternals.php
+++ b/inc/class-antivirus-checkinternals.php
@@ -233,8 +233,11 @@ class AntiVirus_CheckInternals extends AntiVirus {
 		);
 
 		// Check option.
-		if ( $matches && $matches[1] && self::_check_file_line( get_option( $matches[1] ), $num ) ) {
-			array_push( $results, 'get_option' );
+		if ( $matches && $matches[1] ) {
+			$opt_value = get_option( $matches[1] );
+			if ( is_string( $opt_value ) && self::_check_file_line( strval( $opt_value ), $num ) ) {
+				array_push( $results, 'get_option' );
+			}
 		}
 
 		if ( $results ) {

--- a/tests/resources/themes/theme1/maliciousoptions
+++ b/tests/resources/themes/theme1/maliciousoptions
@@ -1,0 +1,7 @@
+$o = get_option( 'evil_string' );
+$o = get_option( 'noevil_string' );
+$o = get_option( 'noevil_int' );
+$o = get_option( 'noevil_array' );
+$o = get_option( 'noevil_object' );
+$o = get_option( 'evil_recursive_string' );
+$o = get_option( 'noevil_recursive_string' );


### PR DESCRIPTION
resolves #96

Scalar option values do convert to string, however that no longer applies to arrays and never did for objects. We now do check for string values before the recursion to avoid warnings. Allowing other scalars would not fail, but there is no check matching numbers or boolean expressions.

----

**Attention:** While this PR solves the reported problem, there is another remaining flaw that was detected: Endless recursion, see first comment of #96 or enable the `endless_recursion` line in the corresponding unit test.
We can either merge this one and add a follow-up fix for this or decide to drop the check and merge PR #97 instead.