### PR TITLE
Drop check for base64 encoded strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### unreleased
 * Drop recursive check on option that failed in several scenarios
+* Drop check for base64 encoded strings which did not work properly in al cases
 * Use WP 5.7 color palette for the UI
 
 ### 1.4.1 ###

--- a/inc/class-antivirus-checkinternals.php
+++ b/inc/class-antivirus-checkinternals.php
@@ -189,18 +189,6 @@ class AntiVirus_CheckInternals extends AntiVirus {
 			$results = $matches[1];
 		}
 
-		// Search for base64 encoded strings.
-		preg_match_all(
-			'/[\'\"\$\\ \/]*?([a-zA-Z0-9]{' . strlen( base64_encode( 'sergej + swetlana = love.' ) ) . ',})/', /* get length of my life ;) */
-			$line,
-			$matches
-		);
-
-		// Save matches.
-		if ( $matches[1] ) {
-			$results = array_merge( $results, $matches[1] );
-		}
-
 		// Look for frames.
 		preg_match_all(
 			'/<\s*?(i?frame)/',
@@ -287,7 +275,7 @@ class AntiVirus_CheckInternals extends AntiVirus {
 		$left = round( ( $max - strlen( $tag ) ) / 2 );
 
 		// Quote regular expression characters.
-		$tag = preg_quote( $tag );
+		$tag = preg_quote( $tag, '/' );
 
 		// Shorten string on the right side.
 		$output = preg_replace(


### PR DESCRIPTION
As the check does not work properly and the fix #95 still causes false positives, I propose to drop this check completely. Later we should implement a checksum-based check (#82).

This is an alternative to #95.