### PR TITLE
Update from deprecated stylelint-config-wordpress to @wordpress/stylelint-config

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "stylelint-config-wordpress",
+  "extends": "@wordpress/stylelint-config",
   "rules": {
     "selector-id-pattern": null
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,9 @@
     "": {
       "devDependencies": {
         "@wordpress/eslint-plugin": "^7.4.0",
+        "@wordpress/stylelint-config": "^19.0.1",
         "eslint": "^7.16.0",
-        "stylelint": "^13.8.0",
-        "stylelint-config-wordpress": "^17.0.0"
+        "stylelint": "^13.8.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -515,6 +515,23 @@
         "node": ">=10"
       }
     },
+    "node_modules/@wordpress/stylelint-config": {
+      "version": "19.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-19.0.1.tgz",
+      "integrity": "sha512-CrYX64Oj2vwrVcTOEu8KYdgD5VPspG+EmJYO8zLQoyTHSFp1XAEdAMKBotKcEAzoTPlT44lD3ch55rT1pUkG+A==",
+      "dev": true,
+      "dependencies": {
+        "stylelint-config-recommended": "^3.0.0",
+        "stylelint-config-recommended-scss": "^4.2.0",
+        "stylelint-scss": "^3.17.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "stylelint": "^13.7.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -842,9 +859,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001198",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001198.tgz",
-      "integrity": "sha512-r5GGgESqOPZzwvdLVER374FpQu2WluCF1Z2DSiFJ89KSmGjT0LVKjgv4NcAqHmGWF9ihNpqRI9KXO9Ex4sKsgA==",
+      "version": "1.0.30001199",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001199.tgz",
+      "integrity": "sha512-ifbK2eChUCFUwGhlEzIoVwzFt1+iriSjyKKFYNfv6hN34483wyWpLLavYQXhnR036LhkdUYaSDpHg1El++VgHQ==",
       "dev": true
     },
     "node_modules/chalk": {
@@ -1154,9 +1171,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.685",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.685.tgz",
-      "integrity": "sha512-C3oFZNkJ8lz85ADqr3hzpjBc2ciejMRN2SCd/D0hwcqpr6MGxfdN/j89VN6l+ERTuCUvhg0VYsf40Q4qTz4bhQ==",
+      "version": "1.3.687",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.687.tgz",
+      "integrity": "sha512-IpzksdQNl3wdgkzf7dnA7/v10w0Utf1dF2L+B4+gKrloBrxCut+au+kky3PYvle3RMdSxZP+UiCZtLbcYRxSNQ==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -1258,9 +1275,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.21.0.tgz",
-      "integrity": "sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==",
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.22.0.tgz",
+      "integrity": "sha512-3VawOtjSJUQiiqac8MQc+w457iGLfuNGLFn8JmF051tTKbh5/x/0vlcEj8OgDCaw7Ysa2Jn8paGshV7x2abKXg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
@@ -1280,7 +1297,7 @@
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
-        "globals": "^12.1.0",
+        "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -1288,7 +1305,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -1561,6 +1578,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/eslint/node_modules/globals": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.6.0.tgz",
+      "integrity": "sha512-YFKCX0SiPg7l5oKYCJ2zZGxcXprVXHcSnVuvzrT3oSENQonVLqM5pf9fN5dLGZGyCjhw8TN8Btwe/jKnZ0pjvQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1580,6 +1612,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/espree": {
@@ -4121,24 +4165,6 @@
         "stylelint-scss": "^3.0.0"
       }
     },
-    "node_modules/stylelint-config-wordpress": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-wordpress/-/stylelint-config-wordpress-17.0.0.tgz",
-      "integrity": "sha512-qUU2kVMd2ezIV9AzRdgietIfnavRRENt4180A1OMoVXIowRjjhohZgBiyVPV5EtNKo3GTO63l8g/QGNG27/h9g==",
-      "deprecated": "This package has been deprecated, please use @wordpress/stylelint-config or @wordpress/scripts",
-      "dev": true,
-      "dependencies": {
-        "stylelint-config-recommended": "^3.0.0",
-        "stylelint-config-recommended-scss": "^4.2.0",
-        "stylelint-scss": "^3.17.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "stylelint": "^10.1.0 || ^11.0.0 || ^12.0.0 || ^13.0.0"
-      }
-    },
     "node_modules/stylelint-scss": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.19.0.tgz",
@@ -4640,9 +4666,9 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.1.tgz",
+      "integrity": "sha512-z/asvd+V08l1ywhaemZVirCwjdzLo6O1/0j2JbYCsGjiezupNQqjs5IIPyNtctbHjPEckqzVGd4jvpU5Lr25vQ==",
       "dev": true,
       "engines": {
         "node": ">= 6"
@@ -5102,6 +5128,17 @@
       "integrity": "sha512-7c4VeugkCwDkaHSD7ffxoP0VC5c///gCTEAT032OhI5Rik2dPxE3EkNAB2NhotGE8M4dMAg4g5Wj2OWZIn8TFw==",
       "dev": true
     },
+    "@wordpress/stylelint-config": {
+      "version": "19.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-19.0.1.tgz",
+      "integrity": "sha512-CrYX64Oj2vwrVcTOEu8KYdgD5VPspG+EmJYO8zLQoyTHSFp1XAEdAMKBotKcEAzoTPlT44lD3ch55rT1pUkG+A==",
+      "dev": true,
+      "requires": {
+        "stylelint-config-recommended": "^3.0.0",
+        "stylelint-config-recommended-scss": "^4.2.0",
+        "stylelint-scss": "^3.17.2"
+      }
+    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -5335,9 +5372,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001198",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001198.tgz",
-      "integrity": "sha512-r5GGgESqOPZzwvdLVER374FpQu2WluCF1Z2DSiFJ89KSmGjT0LVKjgv4NcAqHmGWF9ihNpqRI9KXO9Ex4sKsgA==",
+      "version": "1.0.30001199",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001199.tgz",
+      "integrity": "sha512-ifbK2eChUCFUwGhlEzIoVwzFt1+iriSjyKKFYNfv6hN34483wyWpLLavYQXhnR036LhkdUYaSDpHg1El++VgHQ==",
       "dev": true
     },
     "chalk": {
@@ -5578,9 +5615,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.685",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.685.tgz",
-      "integrity": "sha512-C3oFZNkJ8lz85ADqr3hzpjBc2ciejMRN2SCd/D0hwcqpr6MGxfdN/j89VN6l+ERTuCUvhg0VYsf40Q4qTz4bhQ==",
+      "version": "1.3.687",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.687.tgz",
+      "integrity": "sha512-IpzksdQNl3wdgkzf7dnA7/v10w0Utf1dF2L+B4+gKrloBrxCut+au+kky3PYvle3RMdSxZP+UiCZtLbcYRxSNQ==",
       "dev": true
     },
     "emoji-regex": {
@@ -5661,9 +5698,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.21.0.tgz",
-      "integrity": "sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==",
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.22.0.tgz",
+      "integrity": "sha512-3VawOtjSJUQiiqac8MQc+w457iGLfuNGLFn8JmF051tTKbh5/x/0vlcEj8OgDCaw7Ysa2Jn8paGshV7x2abKXg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
@@ -5683,7 +5720,7 @@
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
-        "globals": "^12.1.0",
+        "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -5691,7 +5728,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -5754,6 +5791,15 @@
           "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
           "dev": true
         },
+        "globals": {
+          "version": "13.6.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.6.0.tgz",
+          "integrity": "sha512-YFKCX0SiPg7l5oKYCJ2zZGxcXprVXHcSnVuvzrT3oSENQonVLqM5pf9fN5dLGZGyCjhw8TN8Btwe/jKnZ0pjvQ==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5768,6 +5814,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
         }
       }
     },
@@ -7825,17 +7877,6 @@
         "stylelint-config-recommended": "^3.0.0"
       }
     },
-    "stylelint-config-wordpress": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-wordpress/-/stylelint-config-wordpress-17.0.0.tgz",
-      "integrity": "sha512-qUU2kVMd2ezIV9AzRdgietIfnavRRENt4180A1OMoVXIowRjjhohZgBiyVPV5EtNKo3GTO63l8g/QGNG27/h9g==",
-      "dev": true,
-      "requires": {
-        "stylelint-config-recommended": "^3.0.0",
-        "stylelint-config-recommended-scss": "^4.2.0",
-        "stylelint-scss": "^3.17.2"
-      }
-    },
     "stylelint-scss": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.19.0.tgz",
@@ -8154,9 +8195,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.1.tgz",
+      "integrity": "sha512-z/asvd+V08l1ywhaemZVirCwjdzLo6O1/0j2JbYCsGjiezupNQqjs5IIPyNtctbHjPEckqzVGd4jvpU5Lr25vQ==",
       "dev": true
     },
     "yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "private": true,
   "devDependencies": {
     "@wordpress/eslint-plugin": "^7.4.0",
+    "@wordpress/stylelint-config": "^19.0.1",
     "eslint": "^7.16.0",
-    "stylelint": "^13.8.0",
-    "stylelint-config-wordpress": "^17.0.0"
+    "stylelint": "^13.8.0"
   }
 }


### PR DESCRIPTION
Update the stylelint configuration from the deprecated [stylelint-config-wordpress](https://github.com/WordPress-Coding-Standards/stylelint-config-wordpress) to [@wordpress/stylelint-config](https://github.com/WordPress/gutenberg/tree/trunk/packages/stylelint-config)

Fixes the warning for [declaration-property-unit-whitelist](https://github.com/stylelint/stylelint/blob/13.7.0/lib/rules/declaration-property-unit-whitelist/README.md) during CSS linting