### PR TITLE
add warning to settings page if SafeBrowsing is enabled without key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### unreleased ###
+* Show warning if Safe Browsing check is enabled without custom API key (#105)
+
 ### 1.4.2 ###
 * Drop recursive check on option that failed in several scenarios (#96) (#97)
 * Drop check for base64 encoded strings which did not work properly in al cases (#100)

--- a/antivirus.php
+++ b/antivirus.php
@@ -8,7 +8,7 @@
  * Text Domain: antivirus
  * License:     GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version:     1.4.2
+ * Version:     1.4.3
  *
  * @package AntiVirus
  */

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -146,12 +146,6 @@ class AntiVirus {
 		if ( self::_cron_enabled( self::_get_options() ) ) {
 			self::_add_scheduled_hook();
 		}
-
-		// Add admin notice, if Safe Browsing is enabled without custom API key.
-		$sb_key = self::_get_option( 'safe_browsing_key' );
-		if ( self::_get_option( 'safe_browsing' ) && empty( $sb_key ) ) {
-			set_transient( 'antivirus-activation-notice', true, 60 );
-		}
 	}
 
 	/**
@@ -592,10 +586,10 @@ class AntiVirus {
 	 * Show notice on the dashboard.
 	 */
 	public static function show_dashboard_notice() {
-		// Show warning if Safe Browsing warning as triggered.
-		if ( get_transient( 'antivirus-activation-notice' ) ) {
+		// Add admin notice, if Safe Browsing is enabled without custom API key.
+		$safe_browsing_key = self::_get_option( 'safe_browsing_key' );
+		if ( self::_get_option( 'safe_browsing' ) && empty( $safe_browsing_key ) ) {
 			self::show_safebrowsing_notice();
-			delete_transient( 'antivirus-activation-notice' );
 		}
 
 		// Only show notice if there's an alert.
@@ -666,11 +660,12 @@ class AntiVirus {
 				</p>
 			</div>
 			<?php
-		}
 
-		$sb_key = self::_get_option( 'safe_browsing_key' );
-		if ( self::_get_option( 'safe_browsing' ) && empty( $sb_key ) ) {
-			self::show_safebrowsing_notice();
+			// Show admin notice for Safe Browsing without API key immediately after saving settings.
+			$safe_browsing_key = self::_get_option( 'safe_browsing_key' );
+			if ( self::_get_option( 'safe_browsing' ) && empty( $safe_browsing_key ) ) {
+				self::show_safebrowsing_notice();
+			}
 		}
 		?>
 
@@ -841,18 +836,24 @@ class AntiVirus {
 	 */
 	private static function show_safebrowsing_notice() {
 		printf(
-			'<div class="notice notice-warning"><p><strong>%1$s</strong></p><p>%2$s</p><p>%3$s %4$s</p></div>',
-			esc_html( 'No Safe Browsing API key provided', 'antivirus' ),
+			'<div class="notice notice-warning is-dismissible"><p><strong>%1$s</strong></p><p>%2$s</p><p>%3$s %4$s</p></div>',
+			esc_html( 'No Safe Browsing API key provided for AntiVirus', 'antivirus' ),
 			esc_html( 'Google Safe Browsing check is enabled without a custom API key. The built-in key is no longer supported and will be be removed with the next release of AntiVirus.', 'antivirus' ),
 			esc_html( 'If you want to continue using this feature, please provide an API key.', 'antivirus' ),
 			wp_kses(
 				sprintf(
 					/* translators: First placeholder (%1$s) starting link tag to the documentation page, second placeholder (%2$s) closing link tag */
 					__( 'See official %1$sdocumentation%2$s.', 'antivirus' ),
-					'<a href="https://cloud.google.com/docs/authentication/api-keys">',
+					'<a href="https://cloud.google.com/docs/authentication/api-keys" target="_blank" rel="noopener noreferrer">',
 					'</a>'
 				),
-				array( 'a' => array( 'href' => array() ) )
+				array(
+					'a' => array(
+						'href' => array(),
+						'target' => array(),
+						'rel' => array(),
+					),
+				)
 			)
 		);
 	}

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -586,10 +586,15 @@ class AntiVirus {
 	 * Show notice on the dashboard.
 	 */
 	public static function show_dashboard_notice() {
-		// Add admin notice, if Safe Browsing is enabled without custom API key.
-		$safe_browsing_key = self::_get_option( 'safe_browsing_key' );
-		if ( self::_get_option( 'safe_browsing' ) && empty( $safe_browsing_key ) ) {
-			self::show_safebrowsing_notice();
+		// Add admin notice to users who can manage options, if Safe Browsing is enabled without custom API key.
+		if ( current_user_can( 'manage_options' ) ) {
+			$screen = get_current_screen();
+			if ( ! is_object( $screen ) || 'settings_page_antivirus' !== $screen->base ) {
+				$safe_browsing_key = self::_get_option( 'safe_browsing_key' );
+				if ( self::_get_option( 'safe_browsing' ) && empty( $safe_browsing_key ) ) {
+					self::show_safebrowsing_notice();
+				}
+			}
 		}
 
 		// Only show notice if there's an alert.
@@ -660,12 +665,12 @@ class AntiVirus {
 				</p>
 			</div>
 			<?php
+		}
 
-			// Show admin notice for Safe Browsing without API key immediately after saving settings.
-			$safe_browsing_key = self::_get_option( 'safe_browsing_key' );
-			if ( self::_get_option( 'safe_browsing' ) && empty( $safe_browsing_key ) ) {
-				self::show_safebrowsing_notice();
-			}
+		// Show admin notice for Safe Browsing without API key immediately after saving settings.
+		$safe_browsing_key = self::_get_option( 'safe_browsing_key' );
+		if ( self::_get_option( 'safe_browsing' ) && empty( $safe_browsing_key ) ) {
+			self::show_safebrowsing_notice();
 		}
 		?>
 

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -852,7 +852,15 @@ class AntiVirus {
 			'<div class="notice notice-warning is-dismissible"><p><strong>%1$s</strong></p><p>%2$s</p><p>%3$s %4$s</p></div>',
 			esc_html( 'No Safe Browsing API key provided for AntiVirus', 'antivirus' ),
 			esc_html( 'Google Safe Browsing check is enabled without a custom API key. The built-in key is no longer supported and will be be removed with the next release of AntiVirus.', 'antivirus' ),
-			esc_html( 'If you want to continue using this feature, please provide an API key.', 'antivirus' ),
+			wp_kses(
+				sprintf(
+					/* translators: First placeholder (%1$s) starting link tag to the plugin settings page, second placeholder (%2$s) closing link tag */
+					__( 'If you want to continue using this feature, please provide an API key using the %1$sAntiVirus settings page%2$s.', 'antivirus' ),
+					'<a href="' . esc_attr( add_query_arg( array( 'page' => 'antivirus' ), admin_url( '/options-general.php' ) ) ) . '">',
+					'</a>'
+				),
+				array( 'a' => array( 'href' => array() ) )
+			),
 			wp_kses(
 				sprintf(
 					/* translators: First placeholder (%1$s) starting link tag to the documentation page, second placeholder (%2$s) closing link tag */

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -856,7 +856,7 @@ class AntiVirus {
 			wp_kses(
 				sprintf(
 					/* translators: First placeholder (%1$s) starting link tag to the documentation page, second placeholder (%2$s) closing link tag */
-					__( 'See official %1$sdocumentation%2$s.', 'antivirus' ),
+					__( 'See official %1$sdocumentation%2$s from Google.', 'antivirus' ),
 					'<a href="https://cloud.google.com/docs/authentication/api-keys" target="_blank" rel="noopener noreferrer">',
 					'</a>'
 				),


### PR DESCRIPTION
Related to #104.

Google Safe Browsing with fallback API key is target for removal, so we inform the user that a custom API key must be provided to continue using this feature.
The warning will be displayed once after activation (upgrade) and always on the plugin's settings page.