### PR TITLE
point Safe Browsing link on settings page to site-specific URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### unreleased ###
+* Point Safe Browsing link on settings page to site-specific URL (#106)
+
 ### 1.4.2 ###
 * Drop recursive check on option that failed in several scenarios (#96) (#97)
 * Drop check for base64 encoded strings which did not work properly in al cases (#100)

--- a/antivirus.php
+++ b/antivirus.php
@@ -8,7 +8,7 @@
  * Text Domain: antivirus
  * License:     GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version:     1.4.2
+ * Version:     1.4.3
  *
  * @package AntiVirus
  */

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -722,12 +722,19 @@ class AntiVirus {
 
 								<p class="description">
 									<?php
-									/* translators: Link for transparency report */
-									$start_tag = sprintf( '<a href="%s">', esc_attr__( 'https://transparencyreport.google.com/safe-browsing/search?hl=en', 'antivirus' ) );
-									$end_tag = '</a>';
+									esc_html_e( 'Diagnosis and notification in suspicion case.', 'antivirus' );
+									echo ' ';
 									echo wp_kses(
-										/* translators: First placeholder (%1$s) starting link tag to transparency report, second placeholder (%2$s) closing link tag */
-										sprintf( __( 'Diagnosis and notification in suspicion case. For more details read %1$sthe transparency report%2$s.', 'antivirus' ), $start_tag, $end_tag ),
+										sprintf(
+											/* translators: First placeholder (%1$s) starting link tag to transparency report, second placeholder (%2$s) closing link tag */
+											__( 'For more details read %1$sthe transparency report%2$s.', 'antivirus' ),
+											sprintf(
+												'<a href="https://transparencyreport.google.com/safe-browsing/search?url=%s&hl=%s">',
+												urlencode( get_bloginfo( 'url' ) ),
+												substr( get_locale(), 0, 2 )
+											),
+											'</a>'
+										),
 										array( 'a' => array( 'href' => array() ) )
 									);
 									?>

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -729,13 +729,19 @@ class AntiVirus {
 											/* translators: First placeholder (%1$s) starting link tag to transparency report, second placeholder (%2$s) closing link tag */
 											__( 'For more details read %1$sthe transparency report%2$s.', 'antivirus' ),
 											sprintf(
-												'<a href="https://transparencyreport.google.com/safe-browsing/search?url=%s&hl=%s">',
+												'<a href="https://transparencyreport.google.com/safe-browsing/search?url=%s&hl=%s" target="_blank" rel="noopener noreferrer">',
 												urlencode( get_bloginfo( 'url' ) ),
 												substr( get_locale(), 0, 2 )
 											),
 											'</a>'
 										),
-										array( 'a' => array( 'href' => array() ) )
+										array(
+											'a' => array(
+												'href'   => array(),
+												'target' => array(),
+												'rel'    => array(),
+											),
+										)
 									);
 									?>
 								</p>


### PR DESCRIPTION
We already generate such link in the warning mail, so why not show it on the settings page, too.

mentioned in #104