### PR TITLE
separate settings and manual scan in admin ui

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -32,7 +32,6 @@ table.av-scan-results .av-status-column {
 }
 
 table.av-scan-results .av-file-column > p {
-	background: #f6f7f7;
 	line-height: 2;
 	padding: 0.5em;
 }
@@ -42,8 +41,9 @@ table.av-scan-results .av-file-column > p a {
 }
 
 table.av-scan-results .av-file-column > p code {
-	float: left;
-	padding: 0.2em 0.5em;
+	background-color: #f0f0f1;
+	border: 1px solid #a7aaad;
+	padding: 0.5em;
 }
 
 table.av-scan-results .av-file-column > p code span {
@@ -51,24 +51,32 @@ table.av-scan-results .av-file-column > p code span {
 	background: #f2d675;
 }
 
-tr.av-status-pending .av-status-column {
+table.av-scan-results tr.av-status-pending .av-status-column {
 	font-style: italic;
 }
 
-tr.av-status-ok td:first-of-type {
+table.av-scan-results tr.av-status-ok {
+	background-color: #edfaef;
+}
+
+table.av-scan-results tr.av-status-ok td:first-of-type {
 	border-left: 4px solid #007017;
 }
 
-tr.av-status-ok .av-status-column {
-	color: #008a20;
+table.av-scan-results tr.av-status-ok .av-status-column {
+	color: #005c12;
 	font-weight: 700;
 }
 
-tr.av-status-warning td:first-of-type {
+table.av-scan-results tr.av-status-warning {
+	background-color: #fcf0f1;
+}
+
+table.av-scan-results tr.av-status-warning td:first-of-type {
 	border-left: 4px solid #b32d2e;
 }
 
-tr.av-status-warning td.av-status-column {
-	color: #d63638;
+table.av-scan-results tr.av-status-warning td.av-status-column {
+	color: #8a2424;
 	font-weight: 700;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -51,6 +51,10 @@ table.av-scan-results .av-file-column > p code span {
 	background: #f2d675;
 }
 
+table.av-scan-results td {
+	color: #3c434a;
+}
+
 table.av-scan-results tr.av-status-pending .av-status-column {
 	font-style: italic;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1,93 +1,74 @@
-/* @group Manual Scan */
+/* Scan controls */
 
-#av_manual_scan {
-	height: 1%;
-	overflow: hidden;
-}
-
-#av_manual_scan a.button {
-	float: left;
-}
-
-#av_manual_scan .alert {
-	float: left;
-	color: #008a20;
-	margin: 0 10px;
-	border: 1px solid #007017;
-	display: none;
-	height: 26px;
-	line-height: 26px;
-	padding: 0 10px;
+span.av-scan-complete {
 	background: #fff;
+	border: 1px solid #007017;
 	border-radius: 3px;
+	color: #008a20;
+	display: inline-block;
+	line-height: 2;
+	margin: 0 10px;
+	padding: 0 0.5em;
 }
 
-#av_main .inside .output {
-	clear: both;
-	height: 1%;
-	margin: 0 0 0 -6px;
-	padding: 0 0 6px;
-	overflow: hidden;
+#av-scan-process .spinner {
+	float: none;
 }
 
-#av_main .inside .output div {
-	float: left;
-	color: #000;
-	margin: 12px 6px 0;
-	padding: 8px 12px 10px;
-	background: #dba617;
-	border-radius: 3px;
 
-	transition: background-color 0.5s linear;
-	-o-transition: background-color 0.5s linear;
-	-ms-transition: background-color 0.5s linear;
-	-moz-transition: background-color 0.5s linear;
-	-webkit-transition: background-color 0.5s linear;
+/* Scan results table. */
+
+table.av-scan-results .av-toggle-column {
+	width: 2.2em;
 }
 
-#av_main .inside .output div.done {
-	background: #008a20;
-	color: #fff;
+table.av-scan-results .av-file-column > p a.button {
+	float: right;
 }
 
-#av_main .inside .output div.danger {
-	width: 97%;
-	background: #d63638;
-	color: #fff;
+table.av-scan-results .av-status-column {
+	text-align: center;
+	width: 7em;
 }
 
-#av_main .inside .output div p {
-	padding: 10px;
-	overflow: hidden;
+table.av-scan-results .av-file-column > p {
 	background: #f6f7f7;
-	white-space: nowrap;
-	border-radius: 3px;
+	line-height: 2;
+	padding: 0.5em;
 }
 
-#av_main .inside .output div p a {
-	margin: 0 6px 12px 0;
+table.av-scan-results .av-file-column > p a {
+	margin: 0 0.5em 0.5em 0.5em;
 }
 
-#av_main .inside .output div p code {
-	clear: both;
+table.av-scan-results .av-file-column > p code {
 	float: left;
-	color: #000;
-	padding: 2px 5px;
-	border-radius: 3px;
+	padding: 0.2em 0.5em;
 }
 
-#av_main .inside .output div p code span {
-	padding: 2px;
+table.av-scan-results .av-file-column > p code span {
+	padding: 0.2em;
 	background: #f2d675;
 }
 
-/* @end group */
-
-
-/* @group WordPress 3.8 Fix */
-
-#av_notify_email {
-	line-height: 1.5;
+tr.av-status-pending .av-status-column {
+	font-style: italic;
 }
 
-/* @end group */
+tr.av-status-ok td:first-of-type {
+	border-left: 4px solid #007017;
+}
+
+tr.av-status-ok .av-status-column {
+	color: #008a20;
+	font-weight: 700;
+}
+
+tr.av-status-warning td:first-of-type {
+	border-left: 4px solid #b32d2e;
+}
+
+tr.av-status-warning td.av-status-column {
+	color: #d63638;
+	font-weight: 700;
+}

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -725,12 +725,15 @@ class AntiVirus {
 					<tr>
 						<th scope="row">
 							<label for="av_cronjob_enable">
-								<?php esc_html_e( 'Check the theme templates for malware', 'antivirus' ); ?>
+								<?php esc_html_e( 'Theme templates scan', 'antivirus' ); ?>
 							</label>
 						</td>
 						<td>
 							<input type="checkbox" name="av_cronjob_enable" id="av_cronjob_enable"
 								   value="1" <?php checked( self::_get_option( 'cronjob_enable' ), 1 ); ?> />
+							<label for="av_cronjob_enable">
+								<?php esc_html_e( 'Enable theme templates scan for malware', 'antivirus' ); ?>
+							</label>
 							<p class="description">
 								<?php
 								$timestamp = wp_next_scheduled( 'antivirus_daily_cronjob' );
@@ -747,14 +750,15 @@ class AntiVirus {
 					</tr>
 					<tr>
 						<th scope="row">
-							<label for="av_safe_browsing">
-								<?php esc_html_e( 'Malware detection by Google Safe Browsing', 'antivirus' ); ?>
-							</label>
+							<?php esc_html_e( 'Google Safe Browsing', 'antivirus' ); ?>
 						</td>
 						<td>
 							<fieldset>
 								<input type="checkbox" name="av_safe_browsing" id="av_safe_browsing"
 									   value="1" <?php checked( self::_get_option( 'safe_browsing' ), 1 ); ?> />
+								<label for="av_safe_browsing">
+									<?php esc_html_e( 'Enable malware detection by Google Safe Browsing', 'antivirus' ); ?>
+								</label>
 								<p class="description">
 									<?php
 									esc_html_e( 'Diagnosis and notification in suspicion case.', 'antivirus' );
@@ -798,15 +802,18 @@ class AntiVirus {
 					<tr>
 						<th scope="row">
 							<label for="av_checksum_verifier">
-								<?php esc_html_e( 'Checksum verification of WordPress core files', 'antivirus' ); ?>
+								<?php esc_html_e( 'Checksum verification', 'antivirus' ); ?>
 							</label>
 						</td>
 						<td>
 							<input type="checkbox" name="av_checksum_verifier" id="av_checksum_verifier"
 								   value="1" <?php checked( self::_get_option( 'checksum_verifier' ), 1 ); ?> />
-								<p class="description">
-									<?php esc_html_e( 'Matches checksums of all WordPress core files against the values provided by the official API.', 'antivirus' ); ?>
-								</p>
+							<label for="av_checksum_verifier">
+								<?php esc_html_e( 'Enable checksum verification of WordPress core files', 'antivirus' ); ?>
+							</label>
+							<p class="description">
+								<?php esc_html_e( 'Matches checksums of all WordPress core files against the values provided by the official API.', 'antivirus' ); ?>
+							</p>
 						</td>
 					</tr>
 					<tr>

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -600,7 +600,8 @@ class AntiVirus {
 			esc_url(
 				add_query_arg(
 					array(
-						'page' => 'antivirus',
+						'page'   => 'antivirus',
+						'av_tab' => 'scan',
 					),
 					admin_url( 'options-general.php' )
 				)

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -354,10 +354,19 @@ class AntiVirus {
 			'av_script',
 			'av_settings',
 			array(
-				'nonce' => wp_create_nonce( 'av_ajax_nonce' ),
-				'msg_1' => esc_js( __( 'Dismiss', 'antivirus' ) ),
-				'msg_3' => esc_js( __( 'Scan finished', 'antivirus' ) ),
-				'msg_4' => esc_js( __( 'Dismiss false positive virus detection', 'antivirus' ) ),
+				'nonce'  => wp_create_nonce( 'av_ajax_nonce' ),
+				'labels' => array(
+					'dismiss'  => esc_js( __( 'Dismiss', 'antivirus' ) ),
+					'complete' => esc_js( __( 'Scan finished', 'antivirus' ) ),
+					'file'     => esc_js( __( 'Theme File', 'antivirus' ) ),
+					'status'   => esc_js( __( 'Check Status', 'antivirus' ) ),
+				),
+				'texts'  => array(
+					'dismiss' => esc_js( __( 'Dismiss false positive virus detection', 'antivirus' ) ),
+					'ok'      => esc_js( __( '✔ OK', 'antivirus' ) ),
+					'pending' => esc_js( __( 'pending', 'antivirus' ) ),
+					'warning' => esc_js( __( '! Warning', 'antivirus' ) ),
+				),
 			)
 		);
 	}
@@ -660,66 +669,92 @@ class AntiVirus {
 				<?php esc_html_e( 'AntiVirus', 'antivirus' ); ?>
 			</h1>
 
-			<table class="form-table">
-				<tr>
-					<th scope="row">
-						<?php esc_html_e( 'Manual malware scan', 'antivirus' ); ?>
-					</th>
-					<td>
-						<div class="inside" id="av_manual_scan">
-							<p>
-								<a href="#" class="button button-primary">
-									<?php esc_html_e( 'Scan the theme templates now', 'antivirus' ); ?>
-								</a>
-								<span class="alert"></span>
-							</p>
+			<h2 class="nav-tab-wrapper">
+				<?php
+				$current_tab = isset( $_GET['av_tab'] ) ? sanitize_text_field( wp_unslash( $_GET['av_tab'] ) ) : 'settings';
+				printf(
+					'<a class="nav-tab%s" href="%s">%s</a>',
+					esc_attr( 'settings' === $current_tab ? ' nav-tab-active' : '' ),
+					esc_url(
+						add_query_arg(
+							array(
+								'page'   => 'antivirus',
+								'av_tab' => 'settings',
+							),
+							admin_url( 'options-general.php' )
+						)
+					),
+					esc_html( 'Settings', 'antivirus' )
+				);
+				printf(
+					'<a class="nav-tab%s" href="%s">%s</a>',
+					esc_attr( 'scan' === $current_tab ? ' nav-tab-active' : '' ),
+					esc_url(
+						add_query_arg(
+							array(
+								'page'   => 'antivirus',
+								'av_tab' => 'scan',
+							),
+							admin_url( 'options-general.php' )
+						)
+					),
+					esc_html( 'Manual Scan', 'antivirus' )
+				);
+				?>
+			</h2>
 
-							<div class="output"></div>
-						</div>
-					</td>
-				</tr>
-			</table>
+			<?php if ( 'scan' === $current_tab ) : ?>
 
+			<p>
+				<a id="av-scan-trigger" href="#" class="button button-primary">
+					<?php esc_html_e( 'Scan the theme templates now', 'antivirus' ); ?>
+				</a>
+				<span id="av-scan-process"></span>
+			</p>
+
+			<div id="av-scan-output" class="av-scan-output"></div>
+
+			<?php else : ?>
 
 			<form id="av_settings" method="post" action="<?php echo esc_url( admin_url( 'options-general.php?page=antivirus' ) ); ?>">
 				<?php wp_nonce_field( 'antivirus' ); ?>
 
+				<h2><?php esc_html_e( 'Daily malware scan', 'antivirus' ); ?></h2>
 				<table class="form-table">
+					<tbody>
 					<tr>
 						<th scope="row">
-							<?php esc_html_e( 'Daily malware scan', 'antivirus' ); ?>
-						</th>
+							<label for="av_cronjob_enable">
+								<?php esc_html_e( 'Check the theme templates for malware', 'antivirus' ); ?>
+							</label>
+						</td>
+						<td>
+							<input type="checkbox" name="av_cronjob_enable" id="av_cronjob_enable"
+								   value="1" <?php checked( self::_get_option( 'cronjob_enable' ), 1 ); ?> />
+							<p class="description">
+								<?php
+								$timestamp = wp_next_scheduled( 'antivirus_daily_cronjob' );
+								if ( $timestamp ) {
+									echo sprintf(
+										'%s: %s',
+										esc_html__( 'Next Run', 'antivirus' ),
+										esc_html( date_i18n( 'd.m.Y H:i:s', $timestamp + get_option( 'gmt_offset' ) * 3600 ) )
+									);
+								}
+								?>
+							</p>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row">
+							<label for="av_safe_browsing">
+								<?php esc_html_e( 'Malware detection by Google Safe Browsing', 'antivirus' ); ?>
+							</label>
+						</td>
 						<td>
 							<fieldset>
-								<label for="av_cronjob_enable">
-									<input type="checkbox" name="av_cronjob_enable" id="av_cronjob_enable"
-										   value="1" <?php checked( self::_get_option( 'cronjob_enable' ), 1 ); ?> />
-									<?php esc_html_e( 'Check the theme templates for malware', 'antivirus' ); ?>
-								</label>
-
-								<p class="description">
-									<?php
-									$timestamp = wp_next_scheduled( 'antivirus_daily_cronjob' );
-									if ( $timestamp ) {
-										echo sprintf(
-											'%s: %s',
-											esc_html__( 'Next Run', 'antivirus' ),
-											esc_html( date_i18n( 'd.m.Y H:i:s', $timestamp + get_option( 'gmt_offset' ) * 3600 ) )
-										);
-									}
-									?>
-								</p>
-							</fieldset>
-
-							<br/>
-
-							<fieldset>
-								<label for="av_safe_browsing">
-									<input type="checkbox" name="av_safe_browsing" id="av_safe_browsing"
-										   value="1" <?php checked( self::_get_option( 'safe_browsing' ), 1 ); ?> />
-									<?php esc_html_e( 'Malware detection by Google Safe Browsing', 'antivirus' ); ?>
-								</label>
-
+								<input type="checkbox" name="av_safe_browsing" id="av_safe_browsing"
+									   value="1" <?php checked( self::_get_option( 'safe_browsing' ), 1 ); ?> />
 								<p class="description">
 									<?php
 									esc_html_e( 'Diagnosis and notification in suspicion case.', 'antivirus' );
@@ -745,50 +780,47 @@ class AntiVirus {
 									);
 									?>
 								</p>
-
-								<br/>
-
+								<br>
 								<label for="av_safe_browsing_key">
 									<?php esc_html_e( 'Safe Browsing API key', 'antivirus' ); ?>
 								</label>
 								<br/>
 								<input type="text" name="av_safe_browsing_key" id="av_safe_browsing_key" size="45"
 									   value="<?php echo esc_attr( self::_get_option( 'safe_browsing_key' ) ); ?>" />
-
 								<p class="description">
 									<?php
 									esc_html_e( 'Provide a custom key for the Google Safe Browsing API (v4). If this value is left empty, a fallback will be used. However, to ensure valid results due to rate limitations, it is recommended to use your own key.', 'antivirus' );
 									?>
 								</p>
 							</fieldset>
-
-							<br/>
-
-							<fieldset>
-								<label for="av_checksum_verifier">
-									<input type="checkbox" name="av_checksum_verifier" id="av_checksum_verifier"
-										   value="1" <?php checked( self::_get_option( 'checksum_verifier' ), 1 ); ?> />
-									<?php esc_html_e( 'Checksum verification of WordPress core files', 'antivirus' ); ?>
-								</label>
-
+						</td>
+					</tr>
+					<tr>
+						<th scope="row">
+							<label for="av_checksum_verifier">
+								<?php esc_html_e( 'Checksum verification of WordPress core files', 'antivirus' ); ?>
+							</label>
+						</td>
+						<td>
+							<input type="checkbox" name="av_checksum_verifier" id="av_checksum_verifier"
+								   value="1" <?php checked( self::_get_option( 'checksum_verifier' ), 1 ); ?> />
 								<p class="description">
 									<?php esc_html_e( 'Matches checksums of all WordPress core files against the values provided by the official API.', 'antivirus' ); ?>
 								</p>
-							</fieldset>
-
-							<br/>
-
-							<fieldset>
-								<label for="av_notify_email"><?php esc_html_e( 'Email address for notifications', 'antivirus' ); ?></label>
-								<input type="text" name="av_notify_email" id="av_notify_email"
-									   value="<?php echo esc_attr( self::_get_option( 'notify_email' ) ); ?>"
-									   class="regular-text"
-									   placeholder="<?php esc_attr_e( 'Email address for notifications', 'antivirus' ); ?>" />
-
-								<p class="description">
-									<?php esc_html_e( 'If the field is empty, the blog admin will be notified.', 'antivirus' ); ?>
-								</p>
-							</fieldset>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row">
+							<label for="av_notify_email"><?php esc_html_e( 'Email address for notifications', 'antivirus' ); ?></label>
+						</td>
+						<td>
+							<input type="text" name="av_notify_email" id="av_notify_email"
+								   value="<?php echo esc_attr( self::_get_option( 'notify_email' ) ); ?>"
+								   class="regular-text"
+								   placeholder="<?php esc_attr_e( 'Email address for notifications', 'antivirus' ); ?>" />
+							<p class="description">
+								<?php esc_html_e( 'If the field is empty, the blog admin will be notified.', 'antivirus' ); ?>
+							</p>
 						</td>
 					</tr>
 
@@ -822,8 +854,11 @@ class AntiVirus {
 							?>
 						</td>
 					</tr>
+					</tbody>
 				</table>
 			</form>
+
+			<?php endif; ?>
 		</div>
 		<?php
 	}

--- a/js/script.js
+++ b/js/script.js
@@ -128,7 +128,7 @@ jQuery( document ).ready(
 						// Initialize output value.
 						var output = '<table class="wp-list-table widefat fixed striped table-view-list av-scan-results">' +
 							'<thead><tr class="av-status-pending">' +
-							'<td class="av-toggle-column"></td>' +
+							'<td class="av-toggle-column check-column"></td>' +
 							'<th class="av-file-column">Theme File</th>' +
 							'<th class="av-status-column">Check Status</th>' +
 							'</tr></thead>' +
@@ -153,7 +153,7 @@ jQuery( document ).ready(
 							avFiles,
 							function( i, val ) {
 								output += '<tr id="av-scan-result-' + i + '">' +
-									'<td class="av-toggle-column"></td>' +
+									'<td class="av-toggle-column check-column"></td>' +
 									'<td class="av-file-column">' + val + '</td>' +
 									'<td class="av-status-column">' + av_settings.texts.pending + '</td>' +
 									'</tr>';
@@ -161,7 +161,7 @@ jQuery( document ).ready(
 						);
 
 						output += '</tbody><tfoot><tr>' +
-							'<td class="av-toggle-column"></td>' +
+							'<td class="av-toggle-column check-column"></td>' +
 							'<th class="av-file-column">' + av_settings.labels.file + '</th>' +
 							'<th class="av-status-column">' + av_settings.labels.status + '</th>' +
 							'</tr></tfoot></table>';


### PR DESCRIPTION
First step for a UI rework. Addresses #22 and is based on the mockups by @00travelgirl00.
This PR does not introduce any new features and does not change our API, s.t. not all features from the mockups are available yet (theme grouping, last scan timestamp, etc.)

Manual theme file scan is not placed in a separate tab.

Settings table uses default WP settings styles and the scan results are presented in a WP-like table structure.
(could be migrated to settings API which would ease real modularization, but not now)

The first column is yet intentionally left empty. In a followup step I'd like to see grouping the files by theme (or maybe file system hierarchy), so toggle controls should be placed there.

<details>
  <summary>Preview (animated)</summary>

  ![settings tab](https://user-images.githubusercontent.com/12963621/114276094-7a39ae00-9a25-11eb-995f-c0471075d9b3.png)
  ![scan tab](https://user-images.githubusercontent.com/12963621/114275570-55dcd200-9a23-11eb-8295-c6881fb2b23d.gif)
</details>

