### PR TITLE
increase the size of the Safe Browsing API input to show the entire key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### unreleased ###
 * Point Safe Browsing link on settings page to site-specific URL (#106)
+* Increase the size of the Safe Browsing API input to show the entire key (#109)
 
 ### 1.4.2 ###
 * Drop recursive check on option that failed in several scenarios (#96) (#97)

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -752,7 +752,7 @@ class AntiVirus {
 									<?php esc_html_e( 'Safe Browsing API key', 'antivirus' ); ?>
 								</label>
 								<br/>
-								<input type="text" name="av_safe_browsing_key" id="av_safe_browsing_key"
+								<input type="text" name="av_safe_browsing_key" id="av_safe_browsing_key" size="45"
 									   value="<?php echo esc_attr( self::_get_option( 'safe_browsing_key' ) ); ?>" />
 
 								<p class="description">


### PR DESCRIPTION
From https://github.com/pluginkollektiv/antivirus/issues/105#issuecomment-840523516
> I would recommend to add `size="45"` to the input field, so that the API key is completely visible in the text field.