### PR TITLE
replace deprecated FILTER_SANITIZE_STRING (#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### unreleased ###
+* Replace `FILTER_SANIITZE_STRING` deprecated since PHP 8.1+ (#126) (#127)
+
 ### 1.4.4 ###
 * Fix warning on SafeBrowsing API errors with PHP 8.1+ (#123)
 * Tested up to WordPress 6.2

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -504,7 +504,7 @@ class AntiVirus {
 
 			case 'check_theme_file':
 				if ( ! empty( $_POST['_theme_file'] ) ) {
-					$theme_file = filter_var( wp_unslash( $_POST['_theme_file'] ), FILTER_SANITIZE_STRING );
+					$theme_file = filter_var( wp_unslash( $_POST['_theme_file'] ), FILTER_UNSAFE_RAW );
 					$lines = AntiVirus_CheckInternals::check_theme_file( $theme_file );
 					if ( $lines ) {
 						foreach ( $lines as $num => $line ) {


### PR DESCRIPTION
resolves #126

In the following method `check_theme_file()` URL sanitization is applied, so we can either use `FILTER_SANITIZE_URL` here as well or simply pass `UNSAFE_RAW` in this case.

https://github.com/pluginkollektiv/antivirus/blob/e55943cdc923ab2e63297cb8d5a9132dc4ac18a6/inc/class-antivirus-checkinternals.php#L83-L87