### PR TITLE
fix click handler for dismiss button

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -64,13 +64,13 @@ jQuery(document).ready(($) => {
 								'</a></p>'
 						);
 
-						$('#av-dismiss-' + md5).click(() => {
+						$('#av-dismiss-' + md5).click((evt) => {
 							$.post(
 								ajaxurl,
 								{
 									action: 'get_ajax_response',
 									_ajax_nonce: avNonce,
-									_file_md5: $(this).attr('id').substring(11),
+									_file_md5: evt.target.id.substring(11),
 									_action_request: 'update_white_list',
 								},
 								(res) => {


### PR DESCRIPTION
Using an arrow function binds "this" to the outer scope instead of the target element. Pass the event parameter and access the event's target to fix the handler.

Fixes: 9aa9542784fb50e408110938dafd1e79b50eb98e