### PR TITLE
script: mark file as OK only if all issues have been dismissed (#135)

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -85,22 +85,23 @@ jQuery(document).ready(($) => {
 									}
 
 									// Get table column above the dismiss button.
-									const parent = $(
+									const issue = $(
 										'#av-dismiss-' + res.data[0]
-									)
-										.parent()
-										.parent();
+									).parent();
+									const col = issue.parent();
 
-									// Hide code details and mark row as "OK".
-									parent.find('p').hide('slow').remove();
-									parent
-										.parent()
-										.addClass('av-status-ok')
-										.removeClass('av-status-warning');
-									parent
-										.parent()
-										.find('td.av-status-column')
-										.text(av_settings.texts.ok);
+									// Hide code details and "dismiss" button.
+									issue.hide('slow').remove();
+
+									// Mark row as "OK", if no more issues are present.
+									if (col.find('p').length === 0) {
+										col.parent()
+											.addClass('av-status-ok')
+											.removeClass('av-status-warning');
+										col.parent()
+											.find('td.av-status-column')
+											.text(av_settings.texts.ok);
+									}
 								}
 							);
 


### PR DESCRIPTION
Fixes #135 

When multiple issues are present in a single file, clicking on "dismiss" should only hide the corresponding line and the file should only be marked as "OK" and turned green, if there are no more issues present.

Refactor the response handler and only remove the parent element to resolve this issue.