### PR TITLE
ci: add workflow to run wp plugin checks

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -2,6 +2,7 @@
 /.git
 /.github
 /.wordpress-org
+/dist
 /node_modules
 /tests
 /vendor

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 /.github export-ignore
 /.wordpress-org export-ignore
 /bin export-ignore
+/dist export-ignore
 /node_modules export-ignore
 /tests export-ignore
 

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -1,0 +1,31 @@
+name: Plugin check
+on:
+  push:
+    branches: [ 'stable', 'release/*' ]
+  pull_request:
+    branches: [ 'stable' ]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+
+      - name: Build
+        run:  composer install --no-interaction
+
+      - name: Package plugin
+        run: |
+          mkdir -p ./dist
+          rsync -rc --exclude-from=.distignore ./ ./dist/antivirus --delete --delete-excluded
+
+      - name: Check WP plugin
+        uses: wordpress/plugin-check-action@v1
+        with:
+          build-dir: ./dist/antivirus

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 css/*.min.css
+dist/
 js/*.min.js
 vendor/
 node_modules/


### PR DESCRIPTION
Only run this action on _stable_ or _release/*_ Branches or PRs against _stable_ for now.
Many code-related checks are already covered by other rules and some additional checks are not well-suited for development versions (e.g. mismatch of version and stable tag). Let's get used to it and eventuelly change extend this in the future, but make sure we do run the full checks before anything hits the stable branch.