### PR TITLE
use add_filter() for plugin meta and action links

### DIFF
--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -59,8 +59,8 @@ class AntiVirus {
 				add_action( 'admin_menu', array( __CLASS__, 'add_sidebar_menu' ) );
 				add_action( 'admin_notices', array( __CLASS__, 'show_dashboard_notice' ) );
 				add_action( 'deactivate_' . self::$base, array( __CLASS__, 'clear_scheduled_hook' ) );
-				add_action( 'plugin_row_meta', array( __CLASS__, 'init_row_meta' ), 10, 2 );
-				add_action( 'plugin_action_links_' . self::$base, array( __CLASS__, 'init_action_links' ) );
+				add_filter( 'plugin_row_meta', array( __CLASS__, 'init_row_meta' ), 10, 2 );
+				add_filter( 'plugin_action_links_' . self::$base, array( __CLASS__, 'init_action_links' ) );
 			}
 		}
 	}

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -51,8 +51,8 @@ class AntiVirus_Test_Plugin extends AntiVirus_TestCase {
 		WP_Mock::expectActionAdded( 'admin_menu', array( AntiVirus::class, 'add_sidebar_menu' ) );
 		WP_Mock::expectActionAdded( 'admin_notices', array( AntiVirus::class, 'show_dashboard_notice' ) );
 		WP_Mock::expectActionAdded( 'deactivate_antivirus.php', array( AntiVirus::class, 'clear_scheduled_hook' ) );
-		WP_Mock::expectActionAdded( 'plugin_row_meta', array( AntiVirus::class, 'init_row_meta' ), 10, 2 );
-		WP_Mock::expectActionAdded( 'plugin_action_links_antivirus.php', array( AntiVirus::class, 'init_action_links' ) );
+		WP_Mock::expectFilterAdded( 'plugin_row_meta', array( AntiVirus::class, 'init_row_meta' ), 10, 2 );
+		WP_Mock::expectFilterAdded( 'plugin_action_links_antivirus.php', array( AntiVirus::class, 'init_action_links' ) );
 		AntiVirus::init();
 		self::assertTrue( true );
 	}


### PR DESCRIPTION
`plugin_row_meta` and `plugin_action_links_*` are both filter hooks and should be used as such.
Replace `add_action()` with `add_filter()` to register our callbacks.