### PR TITLE
raise minimum WordPress version to 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 * Contributors:      pluginkollektiv
 * Tags:              antivirus, malware, scanner, safe browsing, vulnerability
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
-* Requires at least: 4.1
+* Requires at least: 5.0
 * Requires PHP:      7.4
 * Tested up to:      6.8
 * Stable tag:        1.5.2

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -135,12 +135,7 @@ class AntiVirus {
 	 */
 	public static function activation(): void {
 		// Add default option.
-		add_option(
-			'antivirus',
-			array(),
-			'',
-			'no'
-		);
+		add_option( 'antivirus', array(), '', false );
 
 		// Add cron schedule.
 		if ( self::_cron_enabled( self::_get_options() ) ) {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,7 +11,7 @@
 	<file>tests</file>
 
 	<!-- Extend from WPCS ruleset -->
-	<config name="minimum_supported_wp_version" value="4.1"/>
+	<config name="minimum_supported_wp_version" value="5.0"/>
 	<rule ref="WordPress"/>
 
 	<!-- Verify i18n text domain -->


### PR DESCRIPTION
**raise minimum WordPress version to 5.0**

Simple version bump in _README.md_ and PHPCS config.

This is a prerequisite for i18n usage in JavaScript (#139)

**use boolean argument for `add_option()` autoload parameter**

Argument `$autoload` accepts a boolean value since WP 4.2¹ and deprecated
string yes/no in WP 6.6². With baseline at WP 5.0 we can safely switch
to boolean `false`.

----

[1] https://github.com/WordPress/wordpress-develop/blob/4.2.0/src/wp-includes/option.php#L398
[2] https://github.com/WordPress/wordpress-develop/blob/6.6.0/src/wp-includes/option.php#L1036