### PR TITLE
do not encode URLs in SafeBrowsing request

### DIFF
--- a/inc/class-antivirus-safebrowsing.php
+++ b/inc/class-antivirus-safebrowsing.php
@@ -55,7 +55,7 @@ class AntiVirus_SafeBrowsing extends AntiVirus {
 							'platformTypes'    => array( 'ANY_PLATFORM' ),
 							'threatEntryTypes' => array( 'URL' ),
 							'threatEntries'    => array(
-								array( 'url' => urlencode( get_bloginfo( 'url' ) ) ),
+								array( 'url' => get_bloginfo( 'url' ) ),
 							),
 						),
 					)

--- a/tests/test-safebrowsing.php
+++ b/tests/test-safebrowsing.php
@@ -81,7 +81,7 @@ class AntiVirus_Safebrowsing_Test extends AntiVirus_TestCase {
 		$entries = $request_body->threatInfo->threatEntries;
 		self::assertCount( 1, $entries, 'unexpected number of requested threat entries' );
 		self::assertEquals(
-			urlencode( 'https://antivirus.pluginkollektiv.org/test/' ),
+			'https://antivirus.pluginkollektiv.org/test/',
 			$entries[0]->url,
 			'unexpected blog URL in requested threat entries'
 		);


### PR DESCRIPTION
The `urlencode()` call is a leftover from the old SafeBrowsing v3 check. The v4 API accepts a list of URLs as JSON in the request body where no special encoding is required.

Apparently it does not break the check as the API seems to accept both, but it is not necessary at this point. Remove it.

----

Introduced in #43 (v1.3.10)

Docs do not mention any kind of encoding and examples are plain:
* https://developers.google.com/safe-browsing/v4/lookup-api#example-threatmatchesfind
* https://developers.google.com/safe-browsing/reference/rest/v4/ThreatEntry

Our request looks like this (I don't want to advertise actual malicious sites, so rewritten to an example URL)

```
POST https://safebrowsing.googleapis.com/v4/threatMatches:find?key=*****
Content-Type: application/json

{
  "client" : {
    "clientId" : "wpantivirus",
    "clientVersion" : "1.6.0"
  },
  "threatInfo" : {
    "threatTypes" : [ "THREAT_TYPE_UNSPECIFIED", "MALWARE", "SOCIAL_ENGINEERING", "UNWANTED_SOFTWARE", "POTENTIALLY_HARMFUL_APPLICATION" ],
    "platformTypes" : [ "ANY_PLATFORM" ],
    "threatEntryTypes" : [ "URL" ],
    "threatEntries" : [ {
      "url" : "https%3A%2F%2Fexample.com%2Fmalicious%2F"
    } ]
  }
}
```

with response

```json
{
  "matches": [
    {
      "threatType": "SOCIAL_ENGINEERING",
      "platformType": "ANY_PLATFORM",
      "threat": {
        "url": "https%3A%2F%2Fallegrolokalnie.pl-oferta2756783.cfd%2F"
      },
      "cacheDuration": "300s",
      "threatEntryType": "URL"
    }
  ]
}
```