### PR TITLE
prepare release of v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+### 1.6.0 ###
+* Requires PHP 7.4 or later (#149)
+* Requires WordPress 5.0 or later (#153)
+* Translate JavaScript strings using WP i18n API (#139)
+* Correct internal filter registration (#150)
+* Remove deprecated constructor methods (#155)
+* Fix encoding of URLs in SafeBrowsing API requests (#156)
+* Rewrite JavaScripts for settings and manual scan (#157)
+* Lock scan button while scan is running
+* Various internal code improvements
+* Add link to Patchstack mVDP (#151) (#152)
+* Tested up to WordPress 6.8 (#148)
+
+
 ### 1.5.2 ###
 * Add JavaScript to page footer (#145)
 * Tested up to WordPress 6.7

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * Requires at least: 5.0
 * Requires PHP:      7.4
 * Tested up to:      6.8
-* Stable tag:        1.5.2
+* Stable tag:        1.6.0
 * License:           GPLv2 or later
 * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -44,6 +44,19 @@ A complete documentation is available on the [AntiVirus website](https://antivir
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team helps validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/9e5fb3ed-fe33-4a1b-9c28-5a8b1b8d5eee)
 
 ## Changelog ##
+
+### 1.5.2 ###
+* Requires PHP 7.4 or later
+* Requires WordPress 5.0 or later
+* Translate JavaScript strings using WP i18n API
+* Correct internal filter registration
+* Remove deprecated constructor methods
+* Fix encoding of URLs in SafeBrowsing API requests
+* Rewrite JavaScripts for settings and manual scan
+* Lock scan button while scan is running
+* Various internal code improvements
+* Add link to Patchstack mVDP
+* Tested up to WordPress 6.8
 
 ### 1.5.2 ###
 * Add JavaScript to page footer (#145)
@@ -106,6 +119,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 For the complete changelog, check out our [GitHub repository](https://github.com/pluginkollektiv/antivirus).
 
 ## Upgrade Notice ##
+
+### 1.6.0 ###
+This version requires at least PHP 7.4 and WordPress 5.0
 
 ### 1.5.2 ###
 Small maintenance release, compatible up to WordPress 6.7.

--- a/antivirus.php
+++ b/antivirus.php
@@ -1,21 +1,23 @@
 <?php
 /**
- * Plugin Name: AntiVirus
- * Description: Security plugin to protect your blog or website against exploits and spam injections.
- * Author:      pluginkollektiv
- * Author URI:  https://pluginkollektiv.org
- * Plugin URI:  https://antivirus.pluginkollektiv.org
- * Text Domain: antivirus
- * License:     GPLv2 or later
- * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version:     1.5.2
+ * Plugin Name:       AntiVirus
+ * Plugin URI:        https://antivirus.pluginkollektiv.org
+ * Description:       Security plugin to protect your blog or website against exploits and spam injections.
+ * Author:            pluginkollektiv
+ * Author URI:        https://pluginkollektiv.org
+ * Version:           1.6.0
+ * Requires at least: 5.0
+ * Requires PHP:      7.4
+ * License:           GPLv2 or later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       antivirus
  *
  * @package AntiVirus
  */
 
 /*
 Copyright (C)  2009-2015 Sergej Müller
-Copyright (C)  2016-2023 pluginkollektiv
+Copyright (C)  2016-2025 pluginkollektiv
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/inc/class-antivirus-safebrowsing.php
+++ b/inc/class-antivirus-safebrowsing.php
@@ -42,7 +42,7 @@ class AntiVirus_SafeBrowsing extends AntiVirus {
 					array(
 						'client'     => array(
 							'clientId'      => 'wpantivirus',
-							'clientVersion' => '1.5.0',
+							'clientVersion' => '1.6.0',
 						),
 						'threatInfo' => array(
 							'threatTypes'      => array(


### PR DESCRIPTION
This PR prepares the release of v1.6.0

* update _antivirus.php_
  * update version number to 1.6.0
  * add header tags for WP and PHP requirements
* update version string for _SafeBrowsing_ client
* update _README.md_
  * Raise "Stable tag:" to 1.6.0
  * add new entry to changelog area
  * add upgrade notice
* update _CHANGELOG.md_

Full git history: https://github.com/pluginkollektiv/antivirus/compare/v1.5.2...develop