### PR TITLE
drop explicit load_plugin_textdomain() call

### DIFF
--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -34,9 +34,6 @@ class AntiVirus {
 		// Save the plugin basename.
 		self::$base = plugin_basename( ANTIVIRUS_FILE );
 
-		// Load translations. Required due to support for WP versions before 4.6.
-		load_plugin_textdomain( 'antivirus' );
-
 		// Register the daily cronjob.
 		add_action( 'antivirus_daily_cronjob', array( __CLASS__, 'do_daily_cronjob' ) );
 


### PR DESCRIPTION
We do not support WordPress before 4.6 anymore (#153), so we can safely drop this explicit call and rely on autoloading the textdmain.