### PR TITLE
fix: preserve event listener on multiple dismiss buttons (#161)

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -50,15 +50,21 @@ document.addEventListener('DOMContentLoaded', () => {
 							.replace(/@span@/g, '<span>')
 							.replace(/@\/span@/g, '</span>');
 
-						row.querySelector('td.av-file-column').innerHTML +=
-							`<p><code>${line}</code> <a href="#" id="av-dismiss-${md5}" class="button" ` +
-							`title="${wp.i18n.__('Dismiss false positive virus detection', 'antivirus')}">` +
-							wp.i18n.__('Dismiss', 'antivirus') +
-							'</a></p>';
-
-						document
-							.getElementById(`av-dismiss-${md5}`)
-							?.addEventListener('click', handleDismiss);
+						const p = document.createElement('p');
+						const code = document.createElement('code');
+						code.innerHTML = line;
+						const btn = document.createElement('a');
+						btn.id = `av-dismiss-${md5}`;
+						btn.href = '#';
+						btn.classList.add('button');
+						btn.title = wp.i18n.__(
+							'Dismiss false positive virus detection',
+							'antivirus'
+						);
+						btn.innerText = wp.i18n.__('Dismiss', 'antivirus');
+						btn.addEventListener('click', handleDismiss);
+						p.append(code, btn);
+						row.querySelector('td.av-file-column').append(p);
 					}
 				} else {
 					const row = document.getElementById(`av-scan-result-${id}`);


### PR DESCRIPTION
resolves #161 

----

Appending to `innerHTML` makes the browser re-render the parent node which removes the previously added event listener.
Because of this only the last "dismiss" button within a file row actually works.

Rewrite the logic to create a node programmatically and append it, so the element does not get reset in the loop.

Fixes: 819272cef9476cc1eeb66bfcaa744f5e07a4adf3