### PR TITLE
prepare release of v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 1.6.1 ###
+* Fixed issue with "dismiss" button if multiple warnings are found for one theme file (#161) (#162)
+
 ### 1.6.0 ###
 * Requires PHP 7.4 or later (#149)
 * Requires WordPress 5.0 or later (#153)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * Requires at least: 5.0
 * Requires PHP:      7.4
 * Tested up to:      6.8
-* Stable tag:        1.6.0
+* Stable tag:        1.6.1
 * License:           GPLv2 or later
 * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -45,7 +45,10 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 ## Changelog ##
 
-### 1.5.2 ###
+### 1.6.1 ###
+* Fixed issue with "dismiss" button if multiple warnings are found for one theme file
+
+### 1.6.0 ###
 * Requires PHP 7.4 or later
 * Requires WordPress 5.0 or later
 * Translate JavaScript strings using WP i18n API
@@ -119,6 +122,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 For the complete changelog, check out our [GitHub repository](https://github.com/pluginkollektiv/antivirus).
 
 ## Upgrade Notice ##
+
+### 1.6.1 ###
+This is a bugfix release which resolves a UI issue. Recommended for all users.
 
 ### 1.6.0 ###
 This version requires at least PHP 7.4 and WordPress 5.0

--- a/antivirus.php
+++ b/antivirus.php
@@ -5,7 +5,7 @@
  * Description:       Security plugin to protect your blog or website against exploits and spam injections.
  * Author:            pluginkollektiv
  * Author URI:        https://pluginkollektiv.org
- * Version:           1.6.0
+ * Version:           1.6.1
  * Requires at least: 5.0
  * Requires PHP:      7.4
  * License:           GPLv2 or later

--- a/inc/class-antivirus-safebrowsing.php
+++ b/inc/class-antivirus-safebrowsing.php
@@ -42,7 +42,7 @@ class AntiVirus_SafeBrowsing extends AntiVirus {
 					array(
 						'client'     => array(
 							'clientId'      => 'wpantivirus',
-							'clientVersion' => '1.6.0',
+							'clientVersion' => '1.6.1',
 						),
 						'threatInfo' => array(
 							'threatTypes'      => array(


### PR DESCRIPTION
This PR prepares the release of v1.6.1

* update _antivirus.php_
  * update version number to 1.6.1
* update version string for _SafeBrowsing_ client
* update _README.md_
  * Raise "Stable tag:" to 1.6.1
  * add new entry to changelog area
  * fix 1.6.0 changelog headline (was 1.5.2)
  * add upgrade notice
* update _CHANGELOG.md_

Full git history: https://github.com/pluginkollektiv/antivirus/compare/v1.6.0...develop