### PR TITLE
Fix: wrap add_query_arg() with esc_url() and __() with esc_html__() in action_links()

### DIFF
--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -70,12 +70,14 @@ class AntiVirus {
 			array(
 				sprintf(
 					'<a href="%s">%s</a>',
-					esc_url( add_query_arg(
-						array(
-							'page' => 'antivirus',
-						),
-						admin_url( 'options-general.php' )
-					) ),
+					esc_url(
+						add_query_arg(
+							array(
+								'page' => 'antivirus',
+							),
+							admin_url( 'options-general.php' )
+						)
+					),
 					esc_html__( 'Settings', 'antivirus' )
 				),
 			)

--- a/inc/class-antivirus.php
+++ b/inc/class-antivirus.php
@@ -70,13 +70,13 @@ class AntiVirus {
 			array(
 				sprintf(
 					'<a href="%s">%s</a>',
-					add_query_arg(
+					esc_url( add_query_arg(
 						array(
 							'page' => 'antivirus',
 						),
 						admin_url( 'options-general.php' )
-					),
-					__( 'Settings', 'antivirus' )
+					) ),
+					esc_html__( 'Settings', 'antivirus' )
 				),
 			)
 		);


### PR DESCRIPTION
## What & Why

`action_links()` in `class-antivirus.php` builds the Settings admin link via `add_query_arg()` and places it directly into a `href` attribute without `esc_url()`. The link text uses `__()` instead of `esc_html__()` — output is unescaped. Both patterns are flagged by the [WordPress Plugin Check](https://wordpress.org/plugins/plugin-check/) tool.

## Root Cause

Two lines in `action_links()`:
- `add_query_arg( array(...), admin_url('admin.php') )` placed directly in `href="%s"` context
- `__( 'Settings', 'antivirus' )` used for link text without `esc_html__`

## The Fix

Wrap `add_query_arg()` with `esc_url()` (consistent with every other admin URL in this file) and replace `__()` with `esc_html__()` on the link label.

## Verify the Fix

1. Activate AntiVirus on a WP install.
2. Navigate to **Plugins → Installed Plugins**.
3. Confirm the "Settings" action link renders correctly and links to the settings page.
4. Run [Plugin Check](https://wordpress.org/plugins/plugin-check/) — the two escaping notices no longer appear.

---
(full disclosure: I had claude help me identify the issue and check my work)